### PR TITLE
feat: create student on login

### DIFF
--- a/backend/internal/database/config/query.sql
+++ b/backend/internal/database/config/query.sql
@@ -9,9 +9,11 @@ FROM students
 WHERE id = $1
 LIMIT 1;
 
--- name: CreateStudents :batchmany
+-- name: UpsertStudents :batchmany
 INSERT INTO students (id, name, email, created_at, updated_at)
 VALUES ($1, $2, $3, NOW(), NOW())
+ON CONFLICT (id)
+DO UPDATE SET name = $2, email = $3, updated_at = NOW()
 RETURNING id;
 
 -- name: CreateCourses :batchmany

--- a/backend/internal/oauth2/authenticator_mock.go
+++ b/backend/internal/oauth2/authenticator_mock.go
@@ -5,10 +5,17 @@ import (
 	"net/url"
 
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/confidential"
-	"github.com/google/uuid"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 
 	"github.com/darylhjd/oams/backend/internal/env"
+)
+
+const (
+	mockAccessToken          = "mock-access-token"
+	mockAccountHomeAccountID = "mock-home-account-id"
+
+	MockAccountPreferredUsername = "NTU0001@e.ntu.edu.sg"
+	MockIDTokenName              = "TESTACC001"
 )
 
 // MockAzureAuthenticator allows us to mock the calls to Microsoft's Azure AD APIs.
@@ -17,9 +24,7 @@ type MockAzureAuthenticator struct {
 }
 
 func (m *MockAzureAuthenticator) Account(_ context.Context, accountID string) (confidential.Account, error) {
-	return confidential.Account{
-		HomeAccountID: accountID,
-	}, nil
+	return m.mockAccount(), nil
 }
 
 func (m *MockAzureAuthenticator) RemoveAccount(_ context.Context, _ confidential.Account) error {
@@ -49,25 +54,33 @@ func (m *MockAzureAuthenticator) AuthCodeURL(context.Context, string, string, []
 }
 
 func (m *MockAzureAuthenticator) AcquireTokenByAuthCode(context.Context, string, string, []string, ...confidential.AcquireByAuthCodeOption) (confidential.AuthResult, error) {
-	return confidential.AuthResult{
-		AccessToken: "mock-access-token",
-		Account: confidential.Account{
-			HomeAccountID: uuid.NewString(),
-		},
-	}, nil
+	return m.mockAuthResult(), nil
 }
 
 func (m *MockAzureAuthenticator) AcquireTokenSilent(context.Context, []string, ...confidential.AcquireSilentOption) (confidential.AuthResult, error) {
-	return confidential.AuthResult{
-		AccessToken: "mock-access-token",
-		Account: confidential.Account{
-			HomeAccountID: uuid.NewString(),
-		},
-	}, nil
+	return m.mockAuthResult(), nil
 }
 
 func (m *MockAzureAuthenticator) GetKeyCache() *jwk.Cache {
 	return m.keyCache
+}
+
+func (m *MockAzureAuthenticator) mockAuthResult() confidential.AuthResult {
+	// Do this because we cannot import IDToken type.
+	var result confidential.AuthResult
+
+	result.AccessToken = mockAccessToken
+	result.Account = m.mockAccount()
+	result.IDToken.Name = MockIDTokenName
+
+	return result
+}
+
+func (m *MockAzureAuthenticator) mockAccount() confidential.Account {
+	return confidential.Account{
+		HomeAccountID:     mockAccountHomeAccountID,
+		PreferredUsername: MockAccountPreferredUsername,
+	}
 }
 
 // NewMockAzureAuthenticator creates a new mock Azure Authenticator client, useful for tests.

--- a/backend/servers/apiserver/common/class_creation.go
+++ b/backend/servers/apiserver/common/class_creation.go
@@ -55,5 +55,5 @@ func (c *ClassCreationData) Validate() bool {
 type ClassGroupData struct {
 	database.CreateClassGroupsParams
 	Sessions []database.CreateClassGroupSessionsParams `json:"sessions"`
-	Students []database.CreateStudentsParams           `json:"students"`
+	Students []database.UpsertStudentsParams           `json:"students"`
 }

--- a/backend/servers/apiserver/common/class_creation_parser.go
+++ b/backend/servers/apiserver/common/class_creation_parser.go
@@ -212,7 +212,7 @@ func parseClassGroups(creationData *ClassCreationData, rows [][]string) error {
 				return fmt.Errorf("%s - unexpected number of columns for student enrollment row", namespace)
 			}
 
-			group.Students = append(group.Students, database.CreateStudentsParams{
+			group.Students = append(group.Students, database.UpsertStudentsParams{
 				ID:    rows[index][studentIdColumn],
 				Name:  rows[index][studentNameColumn],
 				Email: pgtype.Text{},

--- a/backend/servers/apiserver/common/class_creation_parser_test.go
+++ b/backend/servers/apiserver/common/class_creation_parser_test.go
@@ -42,7 +42,7 @@ func TestParseClassCreationFile(t *testing.T) {
 							ClassType: database.ClassTypeLAB,
 						},
 						[]database.CreateClassGroupSessionsParams{},
-						[]database.CreateStudentsParams{
+						[]database.UpsertStudentsParams{
 							{"CHUL6789", "CHUA LI TING", pgtype.Text{}},
 							{"YAPW9087", "YAP WEN LI", pgtype.Text{}},
 						},
@@ -53,7 +53,7 @@ func TestParseClassCreationFile(t *testing.T) {
 							ClassType: database.ClassTypeLAB,
 						},
 						[]database.CreateClassGroupSessionsParams{},
-						[]database.CreateStudentsParams{
+						[]database.UpsertStudentsParams{
 							{"BENST129", "BENJAMIN SANTOS", pgtype.Text{}},
 							{"YAPW9087", "YAP WEI LING", pgtype.Text{}},
 						},
@@ -64,7 +64,7 @@ func TestParseClassCreationFile(t *testing.T) {
 							ClassType: database.ClassTypeLAB,
 						},
 						[]database.CreateClassGroupSessionsParams{},
-						[]database.CreateStudentsParams{
+						[]database.UpsertStudentsParams{
 							{"PATELAR14", "ARJUN PATEL", pgtype.Text{}},
 							{"YAPX9087", "YAP XIN TING", pgtype.Text{}},
 						},
@@ -94,7 +94,7 @@ func TestParseClassCreationFile(t *testing.T) {
 							ClassType: database.ClassTypeLEC,
 						},
 						[]database.CreateClassGroupSessionsParams{},
-						[]database.CreateStudentsParams{
+						[]database.UpsertStudentsParams{
 							{"PATELAR14", "ARJUN PATEL", pgtype.Text{}},
 							{"YAPX9087", "YAP XIN TING", pgtype.Text{}},
 						},
@@ -124,7 +124,7 @@ func TestParseClassCreationFile(t *testing.T) {
 							ClassType: database.ClassTypeTUT,
 						},
 						[]database.CreateClassGroupSessionsParams{},
-						[]database.CreateStudentsParams{
+						[]database.UpsertStudentsParams{
 							{"CHUL6789", "CHUA LI TING", pgtype.Text{}},
 							{"YAPW9087", "YAP WEN LI", pgtype.Text{}},
 						},
@@ -135,7 +135,7 @@ func TestParseClassCreationFile(t *testing.T) {
 							ClassType: database.ClassTypeTUT,
 						},
 						[]database.CreateClassGroupSessionsParams{},
-						[]database.CreateStudentsParams{
+						[]database.UpsertStudentsParams{
 							{"BENST129", "BENJAMIN SANTOS", pgtype.Text{}},
 							{"YAPW9087", "YAP WEI LING", pgtype.Text{}},
 						},
@@ -146,7 +146,7 @@ func TestParseClassCreationFile(t *testing.T) {
 							ClassType: database.ClassTypeTUT,
 						},
 						[]database.CreateClassGroupSessionsParams{},
-						[]database.CreateStudentsParams{
+						[]database.UpsertStudentsParams{
 							{"PATELAR14", "ARJUN PATEL", pgtype.Text{}},
 							{"YAPX9087", "YAP XIN TING", pgtype.Text{}},
 						},

--- a/backend/servers/apiserver/v1/classes_create_test.go
+++ b/backend/servers/apiserver/v1/classes_create_test.go
@@ -83,7 +83,7 @@ func TestAPIServerV1_classesCreate(t *testing.T) {
 										ClassType: database.ClassTypeLAB,
 									},
 									[]database.CreateClassGroupSessionsParams{},
-									[]database.CreateStudentsParams{
+									[]database.UpsertStudentsParams{
 										{"CHUL6789", "CHUA LI TING", pgtype.Text{}},
 										{"YAPW9087", "YAP WEN LI", pgtype.Text{}},
 									},
@@ -94,7 +94,7 @@ func TestAPIServerV1_classesCreate(t *testing.T) {
 										ClassType: database.ClassTypeLAB,
 									},
 									[]database.CreateClassGroupSessionsParams{},
-									[]database.CreateStudentsParams{
+									[]database.UpsertStudentsParams{
 										{"BENST129", "BENJAMIN SANTOS", pgtype.Text{}},
 										{"YAPW9087", "YAP WEI LING", pgtype.Text{}},
 									},
@@ -105,7 +105,7 @@ func TestAPIServerV1_classesCreate(t *testing.T) {
 										ClassType: database.ClassTypeLAB,
 									},
 									[]database.CreateClassGroupSessionsParams{},
-									[]database.CreateStudentsParams{
+									[]database.UpsertStudentsParams{
 										{"PATELAR14", "ARJUN PATEL", pgtype.Text{}},
 										{"YAPX9087", "YAP XIN TING", pgtype.Text{}},
 									},

--- a/backend/servers/apiserver/v1/ms_login_callback_test.go
+++ b/backend/servers/apiserver/v1/ms_login_callback_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/darylhjd/oams/backend/internal/database"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/darylhjd/oams/backend/internal/oauth2"
@@ -73,6 +75,20 @@ func TestAPIServerV1_msLoginCallback(t *testing.T) {
 			if tt.wantCode != http.StatusSeeOther {
 				return
 			}
+
+			// Check that student exists in the database.
+			student, err := v1.db.Q.GetStudent(req.Context(), oauth2.MockIDTokenName)
+			a.Nil(err)
+			a.Equal(student, database.Student{
+				ID:   oauth2.MockIDTokenName,
+				Name: "",
+				Email: pgtype.Text{
+					String: oauth2.MockAccountPreferredUsername,
+					Valid:  true,
+				},
+				CreatedAt: student.CreatedAt,
+				UpdatedAt: student.UpdatedAt,
+			})
 
 			// Check that session cookie exists.
 			for _, cookie := range rr.Result().Cookies() {


### PR DESCRIPTION
## Issue

Currently, the login flow simply redirects the user back to the redirect url and sets a http cookie for the browser. We want the login flow to also save information on the user that is logging in, i.e. the student that logs in.

## Describe this PR

1. Upsert student on msLoginCallback.
2. Update tests.
3. Update mock authenticator.

## Test Plan

```go test ./...```

## Rollback Plan

Revert the PR.
