### PR TITLE
feat: use upsert instead of insert

### DIFF
--- a/backend/internal/database/config/migrations/000001_initial.up.sql
+++ b/backend/internal/database/config/migrations/000001_initial.up.sql
@@ -21,7 +21,8 @@ CREATE TABLE courses
     au         SMALLINT  NOT NULL,
     created_at TIMESTAMP NOT NULL,
     updated_at TIMESTAMP NOT NULL,
-    UNIQUE (code, year, semester)
+    CONSTRAINT ux_code_year_semester
+        UNIQUE (code, year, semester)
 );
 
 CREATE TABLE class_groups
@@ -32,7 +33,8 @@ CREATE TABLE class_groups
     class_type CLASS_TYPE NOT NULL,
     created_at TIMESTAMP  NOT NULL,
     updated_at TIMESTAMP  NOT NULL,
-    UNIQUE (course_id, name),
+    CONSTRAINT ux_course_id_name
+        UNIQUE (course_id, name),
     CONSTRAINT fk_course_id
         FOREIGN KEY (course_id)
             REFERENCES courses (id)
@@ -47,7 +49,8 @@ CREATE TABLE class_group_sessions
     venue          TEXT      NOT NULL,
     created_at     TIMESTAMP NOT NULL,
     updated_at     TIMESTAMP NOT NULL,
-    UNIQUE (class_group_id, start_time),
+    CONSTRAINT ux_class_group_id_start_time
+        UNIQUE (class_group_id, start_time),
     CONSTRAINT fk_class_group_id
         FOREIGN KEY (class_group_id)
             REFERENCES class_groups (id)
@@ -57,6 +60,7 @@ CREATE TABLE session_enrollments
 (
     session_id BIGSERIAL NOT NULL,
     student_id TEXT      NOT NULL,
+    created_at TIMESTAMP NOT NULL,
     PRIMARY KEY (session_id, student_id),
     CONSTRAINT fk_session_id
         FOREIGN KEY (session_id)

--- a/backend/internal/database/config/query.sql
+++ b/backend/internal/database/config/query.sql
@@ -13,25 +13,39 @@ LIMIT 1;
 INSERT INTO students (id, name, email, created_at, updated_at)
 VALUES ($1, $2, $3, NOW(), NOW())
 ON CONFLICT (id)
-DO UPDATE SET name = $2, email = $3, updated_at = NOW()
-RETURNING id;
+    DO UPDATE SET name       = $2,
+                  email      = $3,
+                  updated_at = NOW()
+RETURNING *;
 
--- name: CreateCourses :batchmany
+-- name: UpsertCourses :batchmany
 INSERT INTO courses (code, year, semester, programme, au, created_at, updated_at)
 VALUES ($1, $2, $3, $4, $5, NOW(), NOW())
-RETURNING id;
+ON CONFLICT ON CONSTRAINT ux_code_year_semester
+    DO UPDATE SET programme  = $4,
+                  au         = $5,
+                  updated_at = NOW()
+RETURNING *;
 
 -- name: CreateClassGroups :batchmany
 INSERT INTO class_groups (course_id, name, class_type, created_at, updated_at)
 VALUES ($1, $2, $3, NOW(), NOW())
-RETURNING id;
+ON CONFLICT ON CONSTRAINT ux_course_id_name
+    DO UPDATE SET class_type = $3,
+                  updated_at = NOW()
+RETURNING *;
 
 -- name: CreateClassGroupSessions :batchmany
 INSERT INTO class_group_sessions (class_group_id, start_time, end_time, venue, created_at, updated_at)
 VALUES ($1, $2, $3, $4, NOW(), NOW())
-RETURNING id;
+ON CONFLICT ON CONSTRAINT ux_class_group_id_start_time
+    DO UPDATE SET end_time   = $3,
+                  venue      = $4,
+                  updated_at = NOW()
+RETURNING *;
 
 -- name: CreateSessionEnrollments :batchmany
-INSERT INTO session_enrollments (session_id, student_id)
-VALUES ($1, $2)
-RETURNING session_id, student_id;
+INSERT INTO session_enrollments (session_id, student_id, created_at)
+VALUES ($1, $2, NOW())
+ON CONFLICT DO NOTHING
+RETURNING *;

--- a/backend/internal/database/models.go
+++ b/backend/internal/database/models.go
@@ -85,8 +85,9 @@ type Course struct {
 }
 
 type SessionEnrollment struct {
-	SessionID int64  `json:"session_id"`
-	StudentID string `json:"student_id"`
+	SessionID int64            `json:"session_id"`
+	StudentID string           `json:"student_id"`
+	CreatedAt pgtype.Timestamp `json:"created_at"`
 }
 
 type Student struct {

--- a/backend/servers/apiserver/common/class_creation.go
+++ b/backend/servers/apiserver/common/class_creation.go
@@ -14,7 +14,7 @@ type ClassCreationData struct {
 	Filename         string    `json:"filename"`
 	FileCreationDate time.Time `json:"file_creation_date"`
 
-	Course      database.CreateCoursesParams `json:"course"`
+	Course      database.UpsertCoursesParams `json:"course"`
 	ClassGroups []ClassGroupData             `json:"class_groups"`
 
 	// Error provides an explanation for any failures while processing the creation data.

--- a/backend/servers/apiserver/common/class_creation_parser_test.go
+++ b/backend/servers/apiserver/common/class_creation_parser_test.go
@@ -28,7 +28,7 @@ func TestParseClassCreationFile(t *testing.T) {
 			ClassCreationData{
 				"class_lab_test.xlsx",
 				time.Date(2023, time.June, 15, 13, 1, 0, 0, loc),
-				database.CreateCoursesParams{
+				database.UpsertCoursesParams{
 					Code:      "SC1015",
 					Year:      2022,
 					Semester:  "2",
@@ -80,7 +80,7 @@ func TestParseClassCreationFile(t *testing.T) {
 			ClassCreationData{
 				"class_lec_test.xlsx",
 				time.Date(2023, time.June, 15, 13, 1, 0, 0, loc),
-				database.CreateCoursesParams{
+				database.UpsertCoursesParams{
 					Code:      "SC1015",
 					Year:      2022,
 					Semester:  "2",
@@ -110,7 +110,7 @@ func TestParseClassCreationFile(t *testing.T) {
 			ClassCreationData{
 				"class_tut_test.xlsx",
 				time.Date(2023, time.June, 15, 13, 1, 0, 0, loc),
-				database.CreateCoursesParams{
+				database.UpsertCoursesParams{
 					Code:      "SC1015",
 					Year:      2022,
 					Semester:  "2",

--- a/backend/servers/apiserver/v1/classes_create_test.go
+++ b/backend/servers/apiserver/v1/classes_create_test.go
@@ -69,7 +69,7 @@ func TestAPIServerV1_classesCreate(t *testing.T) {
 						{
 							"class_lab_test.xlsx",
 							time.Date(2023, time.June, 15, 13, 1, 0, 0, time.Local),
-							database.CreateCoursesParams{
+							database.UpsertCoursesParams{
 								Code:      "SC1015",
 								Year:      2022,
 								Semester:  "2",
@@ -125,7 +125,7 @@ func TestAPIServerV1_classesCreate(t *testing.T) {
 				return bytes.NewReader(b), "application/json", nil
 			},
 			expectedBody: classesCreateResponse{
-				{Course: database.CreateCoursesParams{}},
+				{Course: database.UpsertCoursesParams{}},
 			},
 		},
 	}


### PR DESCRIPTION
## Issue

Currently, sqlc implementation uses pure Inserts, but we can change it to support updates if possible (Upserts).

## Describe this PR

1. Change inserts to upserts.

## Test Plan

```go test ./...```

## Rollback Plan

Revert the PR. Rollback database migration.