### PR TITLE
fix: move `a` into t.Run

### DIFF
--- a/backend/cmd/dbmigrate/validate_test.go
+++ b/backend/cmd/dbmigrate/validate_test.go
@@ -170,9 +170,10 @@ func Test_validateArguments(t *testing.T) {
 		},
 	}
 
-	a := assert.New(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			a := assert.New(t)
+
 			err := validateArguments(&(tt.args))
 			a.Equal(tt.wantErr, err != nil)
 

--- a/backend/internal/env/env_test.go
+++ b/backend/internal/env/env_test.go
@@ -16,9 +16,9 @@ func Test_checkVarEmpty(t *testing.T) {
 		"":    true,
 	}
 
-	a := assert.New(t)
 	for tt, wantErr := range tests {
 		t.Run(fmt.Sprintf("with variable %+q", tt), func(t *testing.T) {
+			a := assert.New(t)
 			a.Equal(wantErr, checkVarEmpty(tt) != nil)
 		})
 	}

--- a/backend/internal/middleware/middleware_test.go
+++ b/backend/internal/middleware/middleware_test.go
@@ -38,9 +38,10 @@ func TestGetAuthContext(t *testing.T) {
 		},
 	}
 
-	a := assert.New(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			a := assert.New(t)
+
 			req := httptest.NewRequest(http.MethodGet, "/", nil)
 			req = req.WithContext(context.WithValue(req.Context(), AuthContextKey, tt.contextValue))
 
@@ -91,9 +92,10 @@ func TestAllowMethods(t *testing.T) {
 		},
 	}
 
-	a := assert.New(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			a := assert.New(t)
+
 			for _, method := range tt.testMethods {
 				req, err := http.NewRequest(method, "", nil)
 				if err != nil {

--- a/backend/internal/oauth2/oauth2_test.go
+++ b/backend/internal/oauth2/oauth2_test.go
@@ -90,9 +90,10 @@ func Test_checkAzureToken(t *testing.T) {
 		},
 	}
 
-	a := assert.New(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			a := assert.New(t)
+
 			privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
 			if err != nil {
 				t.Fatal(err)
@@ -128,9 +129,10 @@ func TestSetSessionCookie(t *testing.T) {
 		tests = append(tests, uuid.NewString())
 	}
 
-	a := assert.New(t)
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("with home account id %+q", tt), func(t *testing.T) {
+			a := assert.New(t)
+
 			authResult := confidential.AuthResult{
 				Account: confidential.Account{
 					HomeAccountID: tt,

--- a/backend/servers/apiserver/common/class_creation_parser_test.go
+++ b/backend/servers/apiserver/common/class_creation_parser_test.go
@@ -214,9 +214,10 @@ func TestParseClassCreationFile(t *testing.T) {
 		},
 	}
 
-	a := assert.New(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			a := assert.New(t)
+
 			file, err := os.Open(tt.file)
 			a.Nil(err)
 

--- a/backend/servers/apiserver/v1/base_test.go
+++ b/backend/servers/apiserver/v1/base_test.go
@@ -29,9 +29,10 @@ func TestAPIServerV1_base(t *testing.T) {
 		},
 	}
 
-	a := assert.New(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			a := assert.New(t)
+
 			v1 := newTestAPIServerV1(t)
 
 			req := httptest.NewRequest(http.MethodGet, tt.path, nil)

--- a/backend/servers/apiserver/v1/classes_create_test.go
+++ b/backend/servers/apiserver/v1/classes_create_test.go
@@ -130,9 +130,10 @@ func TestAPIServerV1_classesCreate(t *testing.T) {
 		},
 	}
 
-	a := assert.New(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			a := assert.New(t)
+
 			body, contentType, err := tt.body()
 			if err != nil {
 				t.Fatal(err)

--- a/backend/servers/apiserver/v1/login_test.go
+++ b/backend/servers/apiserver/v1/login_test.go
@@ -28,9 +28,10 @@ func TestAPIServerV1_login(t *testing.T) {
 		},
 	}
 
-	a := assert.New(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			a := assert.New(t)
+
 			v1 := newTestAPIServerV1(t)
 
 			loginQueries := url.Values{}

--- a/backend/servers/apiserver/v1/ms_login_callback_test.go
+++ b/backend/servers/apiserver/v1/ms_login_callback_test.go
@@ -53,9 +53,10 @@ func TestAPIServerV1_msLoginCallback(t *testing.T) {
 		},
 	}
 
-	a := assert.New(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			a := assert.New(t)
+
 			v1 := newTestAPIServerV1(t)
 
 			s, err := json.Marshal(tt.state)

--- a/backend/servers/apiserver/v1/sign_out_test.go
+++ b/backend/servers/apiserver/v1/sign_out_test.go
@@ -42,9 +42,10 @@ func TestAPIServerV1_signOut(t *testing.T) {
 		},
 	}
 
-	a := assert.New(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			a := assert.New(t)
+
 			v1 := newTestAPIServerV1(t)
 
 			req := httptest.NewRequest(http.MethodGet, signOutUrl, nil)

--- a/backend/servers/apiserver/v1/users_test.go
+++ b/backend/servers/apiserver/v1/users_test.go
@@ -41,9 +41,10 @@ func TestAPIServerV1_users(t *testing.T) {
 		},
 	}
 
-	a := assert.New(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			a := assert.New(t)
+
 			v1 := newTestAPIServerV1(t)
 
 			req := httptest.NewRequest(http.MethodGet, usersUrl, nil)

--- a/backend/servers/webserver/server_test.go
+++ b/backend/servers/webserver/server_test.go
@@ -24,9 +24,10 @@ func TestWebServer(t *testing.T) {
 		"/nested/pages",
 	}
 
-	a := assert.New(t)
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("with request path %+q", tt), func(t *testing.T) {
+			a := assert.New(t)
+
 			reqUrl, err := url.JoinPath(server.URL, tt)
 			a.Nil(err)
 


### PR DESCRIPTION
## Issue

Currently, `a := assert.New(t)` is done outside each individual t.Run. I found out that this causes tests not to fail until all tests in the table are completed, and this prevents us from finding out which individual test case failed.

## Describe this PR

The fix is to create a new `a` for each test case.

## Test Plan

```go test ./...```

## Rollback Plan

Revert the PR.