### PR TITLE
fix: rename database queries

### DIFF
--- a/backend/internal/database/config/query.sql
+++ b/backend/internal/database/config/query.sql
@@ -9,7 +9,7 @@ FROM students
 WHERE id = $1
 LIMIT 1;
 
--- name: UpsertStudents :batchmany
+-- name: UpsertStudents :batchone
 INSERT INTO students (id, name, email, created_at, updated_at)
 VALUES ($1, $2, $3, NOW(), NOW())
 ON CONFLICT (id)
@@ -18,7 +18,7 @@ ON CONFLICT (id)
                   updated_at = NOW()
 RETURNING *;
 
--- name: UpsertCourses :batchmany
+-- name: UpsertCourses :batchone
 INSERT INTO courses (code, year, semester, programme, au, created_at, updated_at)
 VALUES ($1, $2, $3, $4, $5, NOW(), NOW())
 ON CONFLICT ON CONSTRAINT ux_code_year_semester
@@ -27,7 +27,7 @@ ON CONFLICT ON CONSTRAINT ux_code_year_semester
                   updated_at = NOW()
 RETURNING *;
 
--- name: CreateClassGroups :batchmany
+-- name: UpsertClassGroups :batchone
 INSERT INTO class_groups (course_id, name, class_type, created_at, updated_at)
 VALUES ($1, $2, $3, NOW(), NOW())
 ON CONFLICT ON CONSTRAINT ux_course_id_name
@@ -35,7 +35,7 @@ ON CONFLICT ON CONSTRAINT ux_course_id_name
                   updated_at = NOW()
 RETURNING *;
 
--- name: CreateClassGroupSessions :batchmany
+-- name: UpsertClassGroupSessions :batchone
 INSERT INTO class_group_sessions (class_group_id, start_time, end_time, venue, created_at, updated_at)
 VALUES ($1, $2, $3, $4, NOW(), NOW())
 ON CONFLICT ON CONSTRAINT ux_class_group_id_start_time
@@ -44,8 +44,7 @@ ON CONFLICT ON CONSTRAINT ux_class_group_id_start_time
                   updated_at = NOW()
 RETURNING *;
 
--- name: CreateSessionEnrollments :batchmany
+-- name: CreateSessionEnrollments :batchone
 INSERT INTO session_enrollments (session_id, student_id, created_at)
 VALUES ($1, $2, NOW())
-ON CONFLICT DO NOTHING
 RETURNING *;

--- a/backend/servers/apiserver/common/class_creation.go
+++ b/backend/servers/apiserver/common/class_creation.go
@@ -53,7 +53,7 @@ func (c *ClassCreationData) Validate() bool {
 
 // ClassGroupData is a struct containing data for creating a class group and its associated sessions.
 type ClassGroupData struct {
-	database.CreateClassGroupsParams
-	Sessions []database.CreateClassGroupSessionsParams `json:"sessions"`
+	database.UpsertClassGroupsParams
+	Sessions []database.UpsertClassGroupSessionsParams `json:"sessions"`
 	Students []database.UpsertStudentsParams           `json:"students"`
 }

--- a/backend/servers/apiserver/common/class_creation_parser.go
+++ b/backend/servers/apiserver/common/class_creation_parser.go
@@ -166,7 +166,7 @@ func parseClassGroups(creationData *ClassCreationData, rows [][]string) error {
 		index += expectedClassGroupIDRows
 		for index+expectedClassGroupSessionRows <= len(rows) && len(rows[index]) != 0 { // For each session for a class group.
 			var (
-				session   database.CreateClassGroupSessionsParams
+				session   database.UpsertClassGroupSessionsParams
 				dayOfWeek string
 				from      string
 				to        string

--- a/backend/servers/apiserver/common/class_creation_parser_test.go
+++ b/backend/servers/apiserver/common/class_creation_parser_test.go
@@ -37,33 +37,33 @@ func TestParseClassCreationFile(t *testing.T) {
 				},
 				[]ClassGroupData{
 					{
-						database.CreateClassGroupsParams{
+						database.UpsertClassGroupsParams{
 							Name:      "A21",
 							ClassType: database.ClassTypeLAB,
 						},
-						[]database.CreateClassGroupSessionsParams{},
+						[]database.UpsertClassGroupSessionsParams{},
 						[]database.UpsertStudentsParams{
 							{"CHUL6789", "CHUA LI TING", pgtype.Text{}},
 							{"YAPW9087", "YAP WEN LI", pgtype.Text{}},
 						},
 					},
 					{
-						database.CreateClassGroupsParams{
+						database.UpsertClassGroupsParams{
 							Name:      "A26",
 							ClassType: database.ClassTypeLAB,
 						},
-						[]database.CreateClassGroupSessionsParams{},
+						[]database.UpsertClassGroupSessionsParams{},
 						[]database.UpsertStudentsParams{
 							{"BENST129", "BENJAMIN SANTOS", pgtype.Text{}},
 							{"YAPW9087", "YAP WEI LING", pgtype.Text{}},
 						},
 					},
 					{
-						database.CreateClassGroupsParams{
+						database.UpsertClassGroupsParams{
 							Name:      "A32",
 							ClassType: database.ClassTypeLAB,
 						},
-						[]database.CreateClassGroupSessionsParams{},
+						[]database.UpsertClassGroupSessionsParams{},
 						[]database.UpsertStudentsParams{
 							{"PATELAR14", "ARJUN PATEL", pgtype.Text{}},
 							{"YAPX9087", "YAP XIN TING", pgtype.Text{}},
@@ -89,11 +89,11 @@ func TestParseClassCreationFile(t *testing.T) {
 				},
 				[]ClassGroupData{
 					{
-						database.CreateClassGroupsParams{
+						database.UpsertClassGroupsParams{
 							Name:      "L1",
 							ClassType: database.ClassTypeLEC,
 						},
-						[]database.CreateClassGroupSessionsParams{},
+						[]database.UpsertClassGroupSessionsParams{},
 						[]database.UpsertStudentsParams{
 							{"PATELAR14", "ARJUN PATEL", pgtype.Text{}},
 							{"YAPX9087", "YAP XIN TING", pgtype.Text{}},
@@ -119,33 +119,33 @@ func TestParseClassCreationFile(t *testing.T) {
 				},
 				[]ClassGroupData{
 					{
-						database.CreateClassGroupsParams{
+						database.UpsertClassGroupsParams{
 							Name:      "A21",
 							ClassType: database.ClassTypeTUT,
 						},
-						[]database.CreateClassGroupSessionsParams{},
+						[]database.UpsertClassGroupSessionsParams{},
 						[]database.UpsertStudentsParams{
 							{"CHUL6789", "CHUA LI TING", pgtype.Text{}},
 							{"YAPW9087", "YAP WEN LI", pgtype.Text{}},
 						},
 					},
 					{
-						database.CreateClassGroupsParams{
+						database.UpsertClassGroupsParams{
 							Name:      "A26",
 							ClassType: database.ClassTypeTUT,
 						},
-						[]database.CreateClassGroupSessionsParams{},
+						[]database.UpsertClassGroupSessionsParams{},
 						[]database.UpsertStudentsParams{
 							{"BENST129", "BENJAMIN SANTOS", pgtype.Text{}},
 							{"YAPW9087", "YAP WEI LING", pgtype.Text{}},
 						},
 					},
 					{
-						database.CreateClassGroupsParams{
+						database.UpsertClassGroupsParams{
 							Name:      "A32",
 							ClassType: database.ClassTypeTUT,
 						},
-						[]database.CreateClassGroupSessionsParams{},
+						[]database.UpsertClassGroupSessionsParams{},
 						[]database.UpsertStudentsParams{
 							{"PATELAR14", "ARJUN PATEL", pgtype.Text{}},
 							{"YAPX9087", "YAP XIN TING", pgtype.Text{}},

--- a/backend/servers/apiserver/v1/classes_create_test.go
+++ b/backend/servers/apiserver/v1/classes_create_test.go
@@ -82,33 +82,33 @@ func TestAPIServerV1_classesCreate(t *testing.T) {
 							},
 							[]common.ClassGroupData{
 								{
-									database.CreateClassGroupsParams{
+									database.UpsertClassGroupsParams{
 										Name:      "A21",
 										ClassType: database.ClassTypeLAB,
 									},
-									[]database.CreateClassGroupSessionsParams{},
+									[]database.UpsertClassGroupSessionsParams{},
 									[]database.UpsertStudentsParams{
 										{"CHUL6789", "CHUA LI TING", pgtype.Text{}},
 										{"YAPW9087", "YAP WEN LI", pgtype.Text{}},
 									},
 								},
 								{
-									database.CreateClassGroupsParams{
+									database.UpsertClassGroupsParams{
 										Name:      "A26",
 										ClassType: database.ClassTypeLAB,
 									},
-									[]database.CreateClassGroupSessionsParams{},
+									[]database.UpsertClassGroupSessionsParams{},
 									[]database.UpsertStudentsParams{
 										{"BENST129", "BENJAMIN SANTOS", pgtype.Text{}},
 										{"YAPW9087", "YAP WEI LING", pgtype.Text{}},
 									},
 								},
 								{
-									database.CreateClassGroupsParams{
+									database.UpsertClassGroupsParams{
 										Name:      "A32",
 										ClassType: database.ClassTypeLAB,
 									},
-									[]database.CreateClassGroupSessionsParams{},
+									[]database.UpsertClassGroupSessionsParams{},
 									[]database.UpsertStudentsParams{
 										{"PATELAR14", "ARJUN PATEL", pgtype.Text{}},
 										{"YAPX9087", "YAP XIN TING", pgtype.Text{}},


### PR DESCRIPTION
## Issue

Currently, some of the queries have inconsistent naming. We want to standardise.

## Describe this PR

1. Rename some queries.

## Test Plan

```go test ./...```

## Rollback Plan

Revert the PR.