### PR TITLE
fix: race condition on tests

### DIFF
--- a/backend/internal/database/tests/connect_test.go
+++ b/backend/internal/database/tests/connect_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestConnectDB(t *testing.T) {
+	t.Parallel()
+
 	a := assert.New(t)
 	id := uuid.NewString()
 
@@ -24,6 +26,8 @@ func TestConnectDB(t *testing.T) {
 }
 
 func TestGetConnectionProperties(t *testing.T) {
+	t.Parallel()
+
 	a := assert.New(t)
 	id := uuid.NewString()
 

--- a/backend/internal/database/tests/migrate_test.go
+++ b/backend/internal/database/tests/migrate_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestMigrations(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	// We need to test in order.

--- a/backend/servers/apiserver/v1/base_test.go
+++ b/backend/servers/apiserver/v1/base_test.go
@@ -35,6 +35,7 @@ func TestAPIServerV1_base(t *testing.T) {
 	}
 
 	for _, tt := range tts {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/backend/servers/apiserver/v1/login_test.go
+++ b/backend/servers/apiserver/v1/login_test.go
@@ -33,6 +33,7 @@ func TestAPIServerV1_login(t *testing.T) {
 	}
 
 	for _, tt := range tts {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/backend/servers/apiserver/v1/ms_login_callback_test.go
+++ b/backend/servers/apiserver/v1/ms_login_callback_test.go
@@ -56,6 +56,7 @@ func TestAPIServerV1_msLoginCallback(t *testing.T) {
 	}
 
 	for _, tt := range tts {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/backend/servers/apiserver/v1/sign_out_test.go
+++ b/backend/servers/apiserver/v1/sign_out_test.go
@@ -48,6 +48,7 @@ func TestAPIServerV1_signOut(t *testing.T) {
 	}
 
 	for _, tt := range tts {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/backend/servers/apiserver/v1/users_test.go
+++ b/backend/servers/apiserver/v1/users_test.go
@@ -52,6 +52,7 @@ func TestAPIServerV1_users(t *testing.T) {
 	}
 
 	for _, tt := range tts {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
## Issue

Currently, we are using parallel tests for apiserver, but in our table-driven testing there is a condition where the test may change.

## Describe this PR

To fix, we assign `tt := tt` so that each `t.Run` uses the exact test case it requires.

## Test Plan

```go test ./...```

## Rollback Plan

Revert the PR.