### PR TITLE
refactor: change function return type for users methods

### DIFF
--- a/backend/servers/apiserver/v1/base.go
+++ b/backend/servers/apiserver/v1/base.go
@@ -18,7 +18,7 @@ func (v *APIServerV1) base(w http.ResponseWriter, r *http.Request) {
 		resp = newErrorResponse(http.StatusNotFound, "endpoint not implemented or is not supported")
 	} else {
 		resp = baseResponse{
-			newSuccessfulResponse(),
+			newSuccessResponse(),
 			"Welcome to OAMS API Service V1! To get started, read the API docs.",
 		}
 	}

--- a/backend/servers/apiserver/v1/base_test.go
+++ b/backend/servers/apiserver/v1/base_test.go
@@ -23,7 +23,7 @@ func TestAPIServerV1_base(t *testing.T) {
 			"valid request to base url",
 			baseUrl,
 			baseResponse{
-				response: newSuccessfulResponse(),
+				response: newSuccessResponse(),
 				Message:  "Welcome to OAMS API Service V1! To get started, read the API docs.",
 			},
 		},

--- a/backend/servers/apiserver/v1/classes_create.go
+++ b/backend/servers/apiserver/v1/classes_create.go
@@ -185,7 +185,7 @@ func (v *APIServerV1) processClassesCreateRequest(ctx context.Context, req class
 		coursesParams []database.UpsertClassesParams
 	)
 	resp := classesCreateResponse{
-		response: newSuccessfulResponse(),
+		response: newSuccessResponse(),
 	}
 
 	defer func() {

--- a/backend/servers/apiserver/v1/classes_create_test.go
+++ b/backend/servers/apiserver/v1/classes_create_test.go
@@ -58,7 +58,7 @@ func TestAPIServerV1_classesCreate(t *testing.T) {
 				return &b, w.FormDataContentType(), w.Close()
 			},
 			classesCreateResponse{
-				newSuccessfulResponse(),
+				newSuccessResponse(),
 				1,
 				3,
 				4,
@@ -170,7 +170,7 @@ func TestAPIServerV1_classesCreate(t *testing.T) {
 				return bytes.NewReader(b), "application/json", nil
 			},
 			wantResponse: classesCreateResponse{
-				response:           newSuccessfulResponse(),
+				response:           newSuccessResponse(),
 				Classes:            1,
 				ClassGroups:        3,
 				ClassGroupSessions: 3,

--- a/backend/servers/apiserver/v1/login.go
+++ b/backend/servers/apiserver/v1/login.go
@@ -64,7 +64,7 @@ func (v *APIServerV1) login(w http.ResponseWriter, r *http.Request) {
 	v.l.Debug(fmt.Sprintf("%s - generated azure login url", namespace), zap.String("url", redirectString))
 
 	v.writeResponse(w, loginUrl, loginResponse{
-		newSuccessfulResponse(),
+		newSuccessResponse(),
 		redirectString,
 	})
 }

--- a/backend/servers/apiserver/v1/login_test.go
+++ b/backend/servers/apiserver/v1/login_test.go
@@ -68,7 +68,7 @@ func TestAPIServerV1_login(t *testing.T) {
 			a.Nil(err)
 
 			expectedResp := loginResponse{
-				newSuccessfulResponse(),
+				newSuccessResponse(),
 				(&url.URL{
 					Scheme:   "https",
 					Host:     "login.microsoftonline.com",

--- a/backend/servers/apiserver/v1/ping.go
+++ b/backend/servers/apiserver/v1/ping.go
@@ -14,7 +14,7 @@ func (v *APIServerV1) ping(w http.ResponseWriter, r *http.Request) {
 	var resp apiResponse
 
 	resp = pingResponse{
-		response: newSuccessfulResponse(),
+		response: newSuccessResponse(),
 		Message:  "Pong~ OAMS API Service is running normally!",
 	}
 

--- a/backend/servers/apiserver/v1/ping_test.go
+++ b/backend/servers/apiserver/v1/ping_test.go
@@ -25,7 +25,7 @@ func TestAPIServerV1_ping(t *testing.T) {
 	v1.ping(rr, req)
 
 	expectedBytes, err := json.Marshal(pingResponse{
-		response: newSuccessfulResponse(),
+		response: newSuccessResponse(),
 		Message:  "Pong~ OAMS API Service is running normally!",
 	})
 	a.Nil(err)

--- a/backend/servers/apiserver/v1/sign_out.go
+++ b/backend/servers/apiserver/v1/sign_out.go
@@ -25,7 +25,7 @@ func (v *APIServerV1) signOut(w http.ResponseWriter, r *http.Request) {
 	case err != nil:
 		resp = newErrorResponse(http.StatusInternalServerError, err.Error())
 	default:
-		resp = signOutResponse{newSuccessfulResponse()}
+		resp = signOutResponse{newSuccessResponse()}
 		if err = v.azure.RemoveAccount(r.Context(), authContext.AuthResult.Account); err != nil {
 			resp = newErrorResponse(http.StatusInternalServerError, err.Error())
 		}

--- a/backend/servers/apiserver/v1/sign_out_test.go
+++ b/backend/servers/apiserver/v1/sign_out_test.go
@@ -27,7 +27,7 @@ func TestAPIServerV1_signOut(t *testing.T) {
 		{
 			"request with account in context",
 			tests.NewMockAuthContext(),
-			signOutResponse{newSuccessfulResponse()},
+			signOutResponse{newSuccessResponse()},
 		},
 		{
 			"request with wrong account type in context",

--- a/backend/servers/apiserver/v1/users.go
+++ b/backend/servers/apiserver/v1/users.go
@@ -7,24 +7,17 @@ import (
 
 // users endpoint returns useful information on the current session user and information on any requested users.
 func (v *APIServerV1) users(w http.ResponseWriter, r *http.Request) {
-	var (
-		resp apiResponse
-		err  error
-	)
+	var resp apiResponse
 
 	switch r.Method {
 	case http.MethodGet:
-		resp, err = v.usersGet(r)
+		resp = v.usersGet(r)
 	case http.MethodPut:
 		resp = newErrorResponse(http.StatusNotImplemented, "")
 	case http.MethodDelete:
 		resp = newErrorResponse(http.StatusNotImplemented, "")
 	default:
 		resp = newErrorResponse(http.StatusMethodNotAllowed, fmt.Sprintf("method %s is not allowed", r.Method))
-	}
-
-	if err != nil {
-		resp = newErrorResponse(http.StatusInternalServerError, err.Error())
 	}
 
 	v.writeResponse(w, usersUrl, resp)

--- a/backend/servers/apiserver/v1/users_methods.go
+++ b/backend/servers/apiserver/v1/users_methods.go
@@ -21,9 +21,9 @@ const (
 	usersGetQueriesIdKey = "ids"
 )
 
-func (v *APIServerV1) usersGet(r *http.Request) (usersGetResponse, error) {
+func (v *APIServerV1) usersGet(r *http.Request) apiResponse {
 	resp := usersGetResponse{
-		response: newSuccessfulResponse(),
+		response: newSuccessResponse(),
 		Users:    []database.User{},
 	}
 
@@ -31,11 +31,11 @@ func (v *APIServerV1) usersGet(r *http.Request) (usersGetResponse, error) {
 	authContext, isSignedIn, err := middleware.GetAuthContext(r)
 	switch {
 	case err != nil:
-		return resp, err
+		return newErrorResponse(http.StatusInternalServerError, err.Error())
 	case isSignedIn:
 		student, err := v.db.Q.GetUser(r.Context(), authContext.AuthResult.IDToken.Name)
 		if err != nil {
-			return resp, err
+			return newErrorResponse(http.StatusInternalServerError, err.Error())
 		}
 
 		resp.SessionUser = &student
@@ -50,9 +50,9 @@ func (v *APIServerV1) usersGet(r *http.Request) (usersGetResponse, error) {
 
 	students, err := v.db.Q.GetUsersByIDs(r.Context(), queries.ids)
 	if err != nil {
-		return resp, err
+		return newErrorResponse(http.StatusInternalServerError, err.Error())
 	}
 
 	resp.Users = append(resp.Users, students...)
-	return resp, err
+	return resp
 }

--- a/backend/servers/apiserver/v1/v1_response.go
+++ b/backend/servers/apiserver/v1/v1_response.go
@@ -24,15 +24,15 @@ func (r response) Code() int {
 	return r.statusCode
 }
 
-// newSuccessfulResponse creates a new response struct with true result and StatusOK status code.
-func newSuccessfulResponse() response {
+// newSuccessResponse creates a new response struct with true result and StatusOK status code.
+func newSuccessResponse() response {
 	return response{true, http.StatusOK}
 }
 
 // errorResponse struct contains fields that all error responses from the API must have.
 type errorResponse struct {
 	response
-	Error *string `json:"error,omitempty"`
+	Error string `json:"error"`
 }
 
 // newErrorResponse creates a new errorResponse. Caller may specify the status code and the error message.
@@ -42,6 +42,6 @@ func newErrorResponse(code int, err string) errorResponse {
 		response{
 			false, code,
 		},
-		&err,
+		err,
 	}
 }


### PR DESCRIPTION
## Issue

Currently, the users methods implementation returns a fixed user response on success and a generic error if there are errors. The generic error is a problem because this does not allow us to specify the response code in the event of an error.

Although it is usually wrong practice to return an interface from a function in go, in this case we can exploit this to return an errorResponse in the case of an error. This will allow us to return the specific response code that we desire.

## Describe this PR

1. Change method functions to return `apiResponse`.
2. Do some minor renaming of the helper functions.

## Test Plan

```go test ./...```

## Rollback Plan

Revert the PR.