### PR TITLE
refactor: update request and response fields for user and users endpoints

### DIFF
--- a/backend/servers/apiserver/v1/users.go
+++ b/backend/servers/apiserver/v1/users.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"time"
 
 	"github.com/darylhjd/oams/backend/internal/database"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 func (v *APIServerV1) users(w http.ResponseWriter, r *http.Request) {
@@ -27,31 +29,106 @@ func (v *APIServerV1) users(w http.ResponseWriter, r *http.Request) {
 
 type usersGetResponse struct {
 	response
-	Users []database.User `json:"users"`
+	Users []usersGetUserResponseFields `json:"users"`
 }
 
-func (v *APIServerV1) usersGet(r *http.Request) apiResponse {
+type usersGetUserResponseFields struct {
+	ID        string            `json:"id"`
+	Name      string            `json:"name"`
+	Email     *string           `json:"email"`
+	Role      database.UserRole `json:"role"`
+	CreatedAt time.Time         `json:"created_at"`
+	UpdatedAt time.Time         `json:"updated_at"`
+}
+
+func (r usersGetResponse) fromDatabaseUsers(users []database.User) usersGetResponse {
 	resp := usersGetResponse{
-		newSuccessResponse(),
-		[]database.User{},
+		response: newSuccessResponse(),
+		Users:    make([]usersGetUserResponseFields, 0, len(users)),
 	}
 
-	students, err := v.db.Q.ListUsers(r.Context())
-	if err != nil {
-		return newErrorResponse(http.StatusInternalServerError, err.Error())
+	for _, user := range users {
+		respUser := usersGetUserResponseFields{
+			ID:        user.ID,
+			Name:      user.Name,
+			Role:      user.Role,
+			CreatedAt: user.CreatedAt.Time,
+			UpdatedAt: user.UpdatedAt.Time,
+		}
+
+		if user.Email.Valid {
+			respUser.Email = &user.Email.String
+		}
+
+		resp.Users = append(resp.Users, respUser)
 	}
 
-	resp.Users = append(resp.Users, students...)
 	return resp
 }
 
+func (v *APIServerV1) usersGet(r *http.Request) apiResponse {
+	users, err := v.db.Q.ListUsers(r.Context())
+	if err != nil {
+		return newErrorResponse(http.StatusInternalServerError, "could not process users get database action")
+	}
+
+	return usersGetResponse{}.fromDatabaseUsers(users)
+}
+
 type usersCreateRequest struct {
-	database.CreateUserParams
+	User usersCreateUserRequestFields `json:"user"`
+}
+
+type usersCreateUserRequestFields struct {
+	ID    string            `json:"id"`
+	Name  string            `json:"name"`
+	Email *string           `json:"email"`
+	Role  database.UserRole `json:"role"`
+}
+
+func (r usersCreateRequest) createUserParams() database.CreateUserParams {
+	params := database.CreateUserParams{
+		ID:   r.User.ID,
+		Name: r.User.Name,
+		Role: r.User.Role,
+	}
+
+	if r.User.Email != nil {
+		params.Email = pgtype.Text{String: *r.User.Email, Valid: true}
+	}
+
+	return params
 }
 
 type usersCreateResponse struct {
 	response
-	User database.CreateUserRow `json:"user"`
+	User usersCreateUserResponseFields `json:"user"`
+}
+
+type usersCreateUserResponseFields struct {
+	ID        string            `json:"id"`
+	Name      string            `json:"name"`
+	Email     *string           `json:"email"`
+	Role      database.UserRole `json:"role"`
+	CreatedAt time.Time         `json:"created_at"`
+}
+
+func (r usersCreateResponse) fromDatabaseCreateUserRow(row database.CreateUserRow) usersCreateResponse {
+	resp := usersCreateResponse{
+		newSuccessResponse(),
+		usersCreateUserResponseFields{
+			ID:        row.ID,
+			Name:      row.Name,
+			Role:      row.Role,
+			CreatedAt: row.CreatedAt.Time,
+		},
+	}
+
+	if row.Email.Valid {
+		resp.User.Email = &row.Email.String
+	}
+
+	return resp
 }
 
 func (v *APIServerV1) usersCreate(r *http.Request) apiResponse {
@@ -68,18 +145,15 @@ func (v *APIServerV1) usersCreate(r *http.Request) apiResponse {
 		return newErrorResponse(http.StatusBadRequest, "could not parse request body")
 	}
 
-	user, err := v.db.Q.CreateUser(r.Context(), req.CreateUserParams)
+	user, err := v.db.Q.CreateUser(r.Context(), req.createUserParams())
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.SQLState() == database.SQLStateDuplicateKeyOrIndex {
 			return newErrorResponse(http.StatusConflict, "user with same id already exists")
 		}
 
-		return newErrorResponse(http.StatusInternalServerError, err.Error())
+		return newErrorResponse(http.StatusInternalServerError, "could not process users post database action")
 	}
 
-	return usersCreateResponse{
-		newSuccessResponse(),
-		user,
-	}
+	return usersCreateResponse{}.fromDatabaseCreateUserRow(user)
 }

--- a/backend/servers/apiserver/v1/users_test.go
+++ b/backend/servers/apiserver/v1/users_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/darylhjd/oams/backend/internal/database"
 	"github.com/darylhjd/oams/backend/internal/tests"
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -64,22 +63,20 @@ func TestAPIServerV1_usersGet(t *testing.T) {
 	t.Parallel()
 
 	tts := []struct {
-		name                    string
-		withStubAuthContextUser bool
-		wantResponse            usersGetResponse
+		name             string
+		withExistingUser bool
+		wantResponse     usersGetResponse
 	}{
 		{
 			"request with user in database",
 			true,
 			usersGetResponse{
 				newSuccessResponse(),
-				[]database.User{
+				[]usersGetUserResponseFields{
 					{
-						ID: tests.MockAuthenticatorIDTokenName,
-						Email: pgtype.Text{
-							String: tests.MockAuthenticatorAccountPreferredUsername,
-							Valid:  true,
-						},
+						ID:    "EXISTING_USER",
+						Email: nil,
+						Role:  database.UserRoleSTUDENT,
 					},
 				},
 			},
@@ -89,7 +86,7 @@ func TestAPIServerV1_usersGet(t *testing.T) {
 			false,
 			usersGetResponse{
 				response: newSuccessResponse(),
-				Users:    []database.User{},
+				Users:    []usersGetUserResponseFields{},
 			},
 		},
 	}
@@ -106,8 +103,10 @@ func TestAPIServerV1_usersGet(t *testing.T) {
 			v1 := newTestAPIServerV1(t, id)
 			defer tests.TearDown(t, v1.db, id)
 
-			if tt.withStubAuthContextUser {
-				tests.StubAuthContextUser(t, ctx, v1.db.Q)
+			if tt.withExistingUser {
+				for _, user := range tt.wantResponse.Users {
+					tests.StubUser(t, ctx, v1.db.Q, user.ID)
+				}
 			}
 
 			req := httptest.NewRequest(http.MethodGet, usersUrl, nil)
@@ -115,6 +114,11 @@ func TestAPIServerV1_usersGet(t *testing.T) {
 			a.True(ok)
 
 			a.Equal(len(tt.wantResponse.Users), len(actualResp.Users))
+			for idx, actualUser := range actualResp.Users {
+				tt.wantResponse.Users[idx].CreatedAt, tt.wantResponse.Users[idx].UpdatedAt = actualUser.CreatedAt, actualUser.UpdatedAt
+			}
+
+			a.Equal(tt.wantResponse, actualResp)
 		})
 	}
 }
@@ -123,20 +127,42 @@ func TestAPIServerV1_usersPost(t *testing.T) {
 	t.Parallel()
 
 	tts := []struct {
-		name                    string
-		withStubAuthContextUser bool
-		wantStatusCode          int
-		wantErr                 string
+		name             string
+		withRequest      usersCreateRequest
+		withExistingUser bool
+		wantResponse     usersCreateResponse
+		wantStatusCode   int
+		wantErr          string
 	}{
 		{
 			"request with no existing user",
+			usersCreateRequest{
+				usersCreateUserRequestFields{
+					ID:   "NEW_USER",
+					Role: database.UserRoleSTUDENT,
+				},
+			},
 			false,
+			usersCreateResponse{
+				newSuccessResponse(),
+				usersCreateUserResponseFields{
+					ID:   "NEW_USER",
+					Role: database.UserRoleSTUDENT,
+				},
+			},
 			http.StatusOK,
 			"",
 		},
 		{
 			"request with existing user",
+			usersCreateRequest{
+				usersCreateUserRequestFields{
+					ID:   "EXISTING_USER",
+					Role: database.UserRoleSTUDENT,
+				},
+			},
 			true,
+			usersCreateResponse{},
 			http.StatusConflict,
 			"user with same id already exists",
 		},
@@ -154,24 +180,16 @@ func TestAPIServerV1_usersPost(t *testing.T) {
 			v1 := newTestAPIServerV1(t, id)
 			defer tests.TearDown(t, v1.db, id)
 
-			if tt.withStubAuthContextUser {
-				tests.StubAuthContextUser(t, ctx, v1.db.Q)
+			if tt.withExistingUser {
+				tests.StubUser(t, ctx, v1.db.Q, tt.withRequest.User.ID)
 			}
 
-			reqBodyBytes, err := json.Marshal(usersCreateRequest{
-				database.CreateUserParams{
-					ID: tests.MockAuthenticatorIDTokenName,
-					Email: pgtype.Text{
-						String: tests.MockAuthenticatorAccountPreferredUsername,
-						Valid:  true,
-					},
-					Role: database.UserRoleSTUDENT,
-				},
-			})
+			reqBodyBytes, err := json.Marshal(tt.withRequest)
 			a.Nil(err)
 
 			req := httptest.NewRequest(http.MethodPost, usersUrl, bytes.NewReader(reqBodyBytes))
 			resp := v1.usersCreate(req)
+			a.Equal(tt.wantStatusCode, resp.Code())
 
 			switch {
 			case tt.wantErr != "":
@@ -181,7 +199,9 @@ func TestAPIServerV1_usersPost(t *testing.T) {
 			default:
 				actualResp, ok := resp.(usersCreateResponse)
 				a.True(ok)
-				a.Equal(tests.MockAuthenticatorIDTokenName, actualResp.User.ID)
+
+				tt.wantResponse.User.CreatedAt = actualResp.User.CreatedAt
+				a.Equal(tt.wantResponse, actualResp)
 			}
 		})
 	}


### PR DESCRIPTION
## Issue

Currently we use the generated structs from the sqlc package directly for our response and request, but they sometimes contain fields that we don't want.

## Describe this PR

1. Use custom types for request and response fields for API.

## Test Plan

```go test ./...```

## Rollback Plan
Revert the PR.