### PR TITLE
feat: implement user delete endpoint

### DIFF
--- a/backend/internal/database/config/sqlc.yaml
+++ b/backend/internal/database/config/sqlc.yaml
@@ -1,7 +1,7 @@
 version: "2"
 sql:
   - engine: "postgresql"
-    queries: ["query.sql", "users.sql"]
+    queries: [ "query.sql", "users.sql" ]
     schema: "migrations/"
     gen:
       go:

--- a/backend/internal/database/config/users.sql
+++ b/backend/internal/database/config/users.sql
@@ -22,10 +22,16 @@ RETURNING id, name, email, role, created_at;
 
 -- name: UpdateUser :one
 UPDATE users
-    SET name = COALESCE(sqlc.narg('name'), name),
-        email = COALESCE(sqlc.narg('email'), email),
-        role = COALESCE(sqlc.narg('role'), role),
-        updated_at = NOW()
+SET name       = COALESCE(sqlc.narg('name'), name),
+    email      = COALESCE(sqlc.narg('email'), email),
+    role       = COALESCE(sqlc.narg('role'), role),
+    updated_at = NOW()
+WHERE id = $1
+RETURNING *;
+
+-- name: DeleteUser :one
+DELETE
+FROM users
 WHERE id = $1
 RETURNING *;
 

--- a/backend/internal/database/users.sql.go
+++ b/backend/internal/database/users.sql.go
@@ -50,6 +50,27 @@ func (q *Queries) CreateUser(ctx context.Context, arg CreateUserParams) (CreateU
 	return i, err
 }
 
+const deleteUser = `-- name: DeleteUser :one
+DELETE
+FROM users
+WHERE id = $1
+RETURNING id, name, email, role, created_at, updated_at
+`
+
+func (q *Queries) DeleteUser(ctx context.Context, id string) (User, error) {
+	row := q.db.QueryRow(ctx, deleteUser, id)
+	var i User
+	err := row.Scan(
+		&i.ID,
+		&i.Name,
+		&i.Email,
+		&i.Role,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const getUser = `-- name: GetUser :one
 SELECT id, name, email, role, created_at, updated_at
 FROM users
@@ -140,10 +161,10 @@ func (q *Queries) ListUsers(ctx context.Context) ([]User, error) {
 
 const updateUser = `-- name: UpdateUser :one
 UPDATE users
-    SET name = COALESCE($2, name),
-        email = COALESCE($3, email),
-        role = COALESCE($4, role),
-        updated_at = NOW()
+SET name       = COALESCE($2, name),
+    email      = COALESCE($3, email),
+    role       = COALESCE($4, role),
+    updated_at = NOW()
 WHERE id = $1
 RETURNING id, name, email, role, created_at, updated_at
 `


### PR DESCRIPTION
## Issue

Currently, no way to delete user by API. We want to support that action.

## Describe this PR

1. Implement.

## Test Plan

```go test ./...```

## Rollback Plan
Revert the PR.