### PR TITLE
feat: implement user me endpoint

### DIFF
--- a/backend/servers/apiserver/v1/logout.go
+++ b/backend/servers/apiserver/v1/logout.go
@@ -8,13 +8,13 @@ import (
 	"github.com/darylhjd/oams/backend/internal/oauth2"
 )
 
-type signOutResponse struct {
+type logoutResponse struct {
 	response
 }
 
-// signOut endpoint invalidates a user session. This is done by requesting that the browser
+// logout endpoint invalidates a user session. This is done by requesting that the browser
 // remove the cookie containing the session information.
-func (v *APIServerV1) signOut(w http.ResponseWriter, r *http.Request) {
+func (v *APIServerV1) logout(w http.ResponseWriter, r *http.Request) {
 	var resp apiResponse
 
 	authContext, isSignedIn, err := middleware.GetAuthContext(r)
@@ -25,12 +25,12 @@ func (v *APIServerV1) signOut(w http.ResponseWriter, r *http.Request) {
 	case err != nil:
 		resp = newErrorResponse(http.StatusInternalServerError, err.Error())
 	default:
-		resp = signOutResponse{newSuccessResponse()}
+		resp = logoutResponse{newSuccessResponse()}
 		if err = v.azure.RemoveAccount(r.Context(), authContext.AuthResult.Account); err != nil {
 			resp = newErrorResponse(http.StatusInternalServerError, err.Error())
 		}
 	}
 
 	_ = oauth2.DeleteSessionCookie(w)
-	v.writeResponse(w, signOutUrl, resp)
+	v.writeResponse(w, logoutUrl, resp)
 }

--- a/backend/servers/apiserver/v1/logout_test.go
+++ b/backend/servers/apiserver/v1/logout_test.go
@@ -27,7 +27,7 @@ func TestAPIServerV1_signOut(t *testing.T) {
 		{
 			"request with account in context",
 			tests.NewMockAuthContext(),
-			signOutResponse{newSuccessResponse()},
+			logoutResponse{newSuccessResponse()},
 		},
 		{
 			"request with wrong account type in context",
@@ -55,10 +55,10 @@ func TestAPIServerV1_signOut(t *testing.T) {
 
 			tests.StubAuthContextUser(t, ctx, v1.db.Q)
 
-			req := httptest.NewRequest(http.MethodGet, signOutUrl, nil)
+			req := httptest.NewRequest(http.MethodGet, logoutUrl, nil)
 			req = req.WithContext(context.WithValue(req.Context(), middleware.AuthContextKey, tt.withAuthContext))
 			rr := httptest.NewRecorder()
-			v1.signOut(rr, req)
+			v1.logout(rr, req)
 
 			expectedBytes, err := json.Marshal(tt.wantResponse)
 			a.Nil(err)

--- a/backend/servers/apiserver/v1/v1.go
+++ b/backend/servers/apiserver/v1/v1.go
@@ -23,7 +23,7 @@ const (
 	pingUrl            = "/ping"
 	loginUrl           = "/login"
 	msLoginCallbackUrl = "/ms-login-callback"
-	signOutUrl         = "/sign-out"
+	logoutUrl          = "/logout"
 	classesUrl         = "/classes/"
 	usersUrl           = "/users"
 	userUrl            = "/users/"
@@ -51,7 +51,7 @@ func (v *APIServerV1) registerHandlers() {
 
 	v.mux.HandleFunc(loginUrl, v.login)
 	v.mux.HandleFunc(msLoginCallbackUrl, middleware.AllowMethods(v.msLoginCallback, http.MethodPost))
-	v.mux.HandleFunc(signOutUrl, middleware.WithAuthContext(v.signOut, v.azure, true))
+	v.mux.HandleFunc(logoutUrl, middleware.WithAuthContext(v.logout, v.azure, true))
 
 	v.mux.HandleFunc(classesUrl, middleware.WithAuthContext(middleware.AllowMethods(v.classesCreate, http.MethodPost), v.azure, true))
 

--- a/frontend/lib/api/client.dart
+++ b/frontend/lib/api/client.dart
@@ -20,8 +20,8 @@ class APIClient {
 
   static const String loginPath = "api/v1/login";
   static const String loginRedirectUrlParam = "redirect_url";
-  static const String logoutPath = "api/v1/sign-out";
-  static const String usersPath = "api/v1/users";
+  static const String logoutPath = "api/v1/logout";
+  static const String userMePath = "api/v1/users/me";
 
   // getLoginURL gets a login URL from the APIServer.
   static Future<String> getLoginURL(String returnTo) async {
@@ -55,10 +55,10 @@ class APIClient {
     return response.statusCode == HttpStatus.ok;
   }
 
-  // getUserInfo returns the user info of the current logged in user.
-  static Future<UsersResponse> getUsers() async {
+  // getSessionUserInfo gets the session user info.
+  static Future<SessionUserInfoResponse> getSessionUserInfo() async {
     final uri = apiUri.replace(
-      path: usersPath,
+      path: userMePath,
     );
 
     final response = await client.get(uri);
@@ -66,6 +66,6 @@ class APIClient {
       return Future.error(const HttpException("cannot get user details"));
     }
 
-    return UsersResponse.fromJson(jsonDecode(response.body));
+    return SessionUserInfoResponse.fromJson(jsonDecode(response.body));
   }
 }

--- a/frontend/lib/api/models.dart
+++ b/frontend/lib/api/models.dart
@@ -10,17 +10,14 @@ class LoginResponse {
       : redirectUrl = json[redirectUrlField];
 }
 
-// User models a response returned from the users API endpoint..
-class UsersResponse {
+// User models a response returned from the users API endpoint.
+class SessionUserInfoResponse {
   final User? sessionUser;
-  final List<User> users;
 
-  UsersResponse.fromJson(Map<String, dynamic> json)
+  SessionUserInfoResponse.fromJson(Map<String, dynamic> json)
       : sessionUser = json["session_user"] == null
             ? null
-            : User.fromJson(json["session_user"]),
-        users = List<User>.from(
-            (json["users"] as List).map((i) => User.fromJson(i)));
+            : User.fromJson(json["session_user"]);
 }
 
 // User models a user entity from the API.
@@ -28,9 +25,11 @@ class User {
   final String id;
   final String name;
   final String email;
+  final String role;
 
   User.fromJson(Map<String, dynamic> json)
       : id = json["id"],
         name = json["name"],
-        email = json["email"];
+        email = json["email"],
+        role = json["role"];
 }

--- a/frontend/lib/providers/session.dart
+++ b/frontend/lib/providers/session.dart
@@ -8,7 +8,7 @@ import 'package:frontend/api/models.dart';
 // the required auth codes and so we cannot read it directly.
 final sessionUserProvider = FutureProvider<User>((ref) async {
   try {
-    var resp = await APIClient.getUsers();
+    var resp = await APIClient.getSessionUserInfo();
     if (resp.sessionUser == null) {
       throw Exception("no session user");
     }


### PR DESCRIPTION
## Issue

Currently, no way to get session user info, which is a regression. We must re-implement.

## Describe this PR

1. Implement `users/me` endpoint.
2. Update frontend to work.
3. Refactor `sign-out` endpoint to `logout` to be more consistent with `login` naming.

## Test Plan

```go test ./...```

## Rollback Plan

Revert the PR.