### PR TITLE
feat: implement classes post endpoint

### DIFF
--- a/backend/internal/database/states.go
+++ b/backend/internal/database/states.go
@@ -1,5 +1,20 @@
 package database
 
-const (
-	SQLStateDuplicateKeyOrIndex = "23505"
+import (
+	"errors"
+
+	"github.com/jackc/pgx/v5/pgconn"
 )
+
+type SQLState string
+
+const (
+	SQLStateDuplicateKeyOrIndex SQLState = "23505"
+)
+
+// ErrSQLState is a helper function to check if a given err corresponds to a *pgconn.PgError
+// and that the error is of a given SQLState.
+func ErrSQLState(err error, wantState SQLState) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.SQLState() == string(wantState)
+}

--- a/backend/servers/apiserver/v1/classes.go
+++ b/backend/servers/apiserver/v1/classes.go
@@ -1,6 +1,8 @@
 package v1
 
 import (
+	"bytes"
+	"encoding/json"
 	"net/http"
 
 	"github.com/darylhjd/oams/backend/internal/database"
@@ -13,7 +15,7 @@ func (v *APIServerV1) classes(w http.ResponseWriter, r *http.Request) {
 	case http.MethodGet:
 		resp = v.classesGet(r)
 	case http.MethodPost:
-		resp = newErrorResponse(http.StatusNotImplemented, "")
+		resp = v.classesPost(r)
 	default:
 		resp = newErrorResponse(http.StatusMethodNotAllowed, "")
 	}
@@ -39,4 +41,42 @@ func (v *APIServerV1) classesGet(r *http.Request) apiResponse {
 
 	resp.Classes = append(resp.Classes, classes...)
 	return resp
+}
+
+type classesPostRequest struct {
+	Class database.CreateClassParams `json:"class"`
+}
+
+type classesPostResponse struct {
+	response
+	Class database.CreateClassRow `json:"class"`
+}
+
+func (v *APIServerV1) classesPost(r *http.Request) apiResponse {
+	var (
+		b   bytes.Buffer
+		req classesPostRequest
+	)
+
+	if _, err := b.ReadFrom(r.Body); err != nil {
+		return newErrorResponse(http.StatusInternalServerError, err.Error())
+	}
+
+	if err := json.Unmarshal(b.Bytes(), &req); err != nil {
+		return newErrorResponse(http.StatusBadRequest, "could not parse request body")
+	}
+
+	class, err := v.db.Q.CreateClass(r.Context(), req.Class)
+	if err != nil {
+		if database.ErrSQLState(err, database.SQLStateDuplicateKeyOrIndex) {
+			return newErrorResponse(http.StatusConflict, "class with same code, year, and semester already exists")
+		}
+
+		return newErrorResponse(http.StatusInternalServerError, "could not process classes post database action")
+	}
+
+	return classesPostResponse{
+		newSuccessResponse(),
+		class,
+	}
 }

--- a/backend/servers/apiserver/v1/users_test.go
+++ b/backend/servers/apiserver/v1/users_test.go
@@ -125,22 +125,22 @@ func TestAPIServerV1_usersPost(t *testing.T) {
 
 	tts := []struct {
 		name             string
-		withRequest      usersCreateRequest
+		withRequest      usersPostRequest
 		withExistingUser bool
-		wantResponse     usersCreateResponse
+		wantResponse     usersPostResponse
 		wantStatusCode   int
 		wantErr          string
 	}{
 		{
 			"request with no existing user",
-			usersCreateRequest{
+			usersPostRequest{
 				database.CreateUserParams{
 					ID:   "NEW_USER",
 					Role: database.UserRoleSTUDENT,
 				},
 			},
 			false,
-			usersCreateResponse{
+			usersPostResponse{
 				newSuccessResponse(),
 				database.CreateUserRow{
 					ID:   "NEW_USER",
@@ -152,14 +152,14 @@ func TestAPIServerV1_usersPost(t *testing.T) {
 		},
 		{
 			"request with existing user",
-			usersCreateRequest{
+			usersPostRequest{
 				database.CreateUserParams{
 					ID:   "EXISTING_USER",
 					Role: database.UserRoleSTUDENT,
 				},
 			},
 			true,
-			usersCreateResponse{},
+			usersPostResponse{},
 			http.StatusConflict,
 			"user with same id already exists",
 		},
@@ -185,7 +185,7 @@ func TestAPIServerV1_usersPost(t *testing.T) {
 			a.Nil(err)
 
 			req := httptest.NewRequest(http.MethodPost, usersUrl, bytes.NewReader(reqBodyBytes))
-			resp := v1.usersCreate(req)
+			resp := v1.usersPost(req)
 			a.Equal(tt.wantStatusCode, resp.Code())
 
 			switch {
@@ -194,7 +194,7 @@ func TestAPIServerV1_usersPost(t *testing.T) {
 				a.True(ok)
 				a.Contains(actualResp.Error, tt.wantErr)
 			default:
-				actualResp, ok := resp.(usersCreateResponse)
+				actualResp, ok := resp.(usersPostResponse)
 				a.True(ok)
 
 				tt.wantResponse.User.CreatedAt = actualResp.User.CreatedAt


### PR DESCRIPTION
## Issue

We want to implement the classes post endpoint.

## Describe this PR

1. Implement.
2. We also rename current `usersCreate` handler to `usersPost` to better fit the naming convention.
3. We also add a helper function to check for SQL state, which provides useful information for why a certain database action failed.

## Test Plan

```go test ./...```

## Rollback Plan

Revert the PR.