### PR TITLE
fix: do not allow users with session user id identifier in users post endpoint

### DIFF
--- a/backend/servers/apiserver/v1/batch.go
+++ b/backend/servers/apiserver/v1/batch.go
@@ -48,7 +48,7 @@ type batchPostResponse struct {
 	SessionEnrollments int `json:"session_enrollments"`
 }
 
-// batchPost is the handler for a request to create classes.
+// batchPost is the handler for a request to create a batch of entities.
 func (v *APIServerV1) batchPost(w http.ResponseWriter, r *http.Request) {
 	var (
 		req  batchPostRequest

--- a/backend/servers/apiserver/v1/users.go
+++ b/backend/servers/apiserver/v1/users.go
@@ -66,6 +66,10 @@ func (v *APIServerV1) usersPost(r *http.Request) apiResponse {
 		return newErrorResponse(http.StatusBadRequest, "could not parse request body")
 	}
 
+	if req.User.ID == sessionUserId {
+		return newErrorResponse(http.StatusUnprocessableEntity, "id is not allowed")
+	}
+
 	user, err := v.db.Q.CreateUser(r.Context(), req.User)
 	if err != nil {
 		if database.ErrSQLState(err, database.SQLStateDuplicateKeyOrIndex) {

--- a/backend/servers/apiserver/v1/users_test.go
+++ b/backend/servers/apiserver/v1/users_test.go
@@ -163,6 +163,19 @@ func TestAPIServerV1_usersPost(t *testing.T) {
 			http.StatusConflict,
 			"user with same id already exists",
 		},
+		{
+			"request with special session user id me",
+			usersPostRequest{
+				database.CreateUserParams{
+					ID:   sessionUserId,
+					Role: database.UserRoleSTUDENT,
+				},
+			},
+			false,
+			usersPostResponse{},
+			http.StatusUnprocessableEntity,
+			"id is not allowed",
+		},
 	}
 
 	for _, tt := range tts {


### PR DESCRIPTION
## Issue

Currently, it is possible to create users with the special user session id identifier `me`. We should disallow this.

## Describe this PR

1. Implement the check.

## Test Plan

```go test ./...```

## Rollback Plan
Revert the PR.