### PR TITLE
feat: implement welcome banner for desktop guest home screen

### DIFF
--- a/backend/servers/apiserver/v1/v1.go
+++ b/backend/servers/apiserver/v1/v1.go
@@ -64,25 +64,25 @@ func (v *APIServerV1) registerHandlers() {
 	v.mux.HandleFunc(usersUrl, middleware.WithAuthContext(
 		middleware.AllowMethods(v.users, http.MethodGet, http.MethodPost),
 		v.azure,
-		false,
+		true,
 	))
 
 	v.mux.HandleFunc(userUrl, middleware.WithAuthContext(
 		middleware.AllowMethods(v.user, http.MethodGet, http.MethodPut, http.MethodDelete),
 		v.azure,
-		false,
+		true,
 	))
 
 	v.mux.HandleFunc(classesUrl, middleware.WithAuthContext(
 		middleware.AllowMethods(v.classes, http.MethodGet, http.MethodPost),
 		v.azure,
-		false,
+		true,
 	))
 
 	v.mux.HandleFunc(classUrl, middleware.WithAuthContext(
 		middleware.AllowMethods(v.class, http.MethodGet, http.MethodPut, http.MethodDelete),
 		v.azure,
-		false,
+		true,
 	))
 }
 

--- a/frontend/lib/router.dart
+++ b/frontend/lib/router.dart
@@ -46,9 +46,9 @@ final routerProvider = Provider<GoRouter>(
                 return NoTransitionPage(
                   key: state.pageKey,
                   child: LoginScreen(
-                    returnTo:
-                        state.queryParameters[APIClient.loginRedirectUrlParam] ??
-                            "",
+                    redirectUrl: state
+                            .queryParameters[APIClient.loginRedirectUrlParam] ??
+                        "",
                   ),
                 );
               },

--- a/frontend/lib/screens/home_screen.dart
+++ b/frontend/lib/screens/home_screen.dart
@@ -1,25 +1,149 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:frontend/providers/session.dart';
+import 'package:frontend/router.dart';
 import 'package:frontend/screens/screen_template.dart';
+import 'package:go_router/go_router.dart';
+import 'package:responsive_framework/responsive_breakpoints.dart';
 
 // HomeScreen shows the home screen.
-class HomeScreen extends StatelessWidget {
-  const HomeScreen({Key? key}) : super(key: key);
+class HomeScreen extends ConsumerWidget {
+  static const double mobilePadding = 10;
+  static const double desktopPadding = 20;
+
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isLoggedIn = ref.read(sessionProvider);
+    return isLoggedIn ? const _HomeScreenLoggedIn() : const _HomeScreenGuest();
+  }
+}
+
+// _HomeScreenLoggedIn shows the logged-in version of the home screen.
+class _HomeScreenLoggedIn extends ConsumerWidget {
+  static const double mobilePadding = 10;
+  static const double desktopPadding = 20;
+
+  const _HomeScreenLoggedIn();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ScreenTemplate(
+      ResponsiveBreakpoints.of(context).isMobile ? mobile() : desktop(),
+    );
+  }
+
+  Widget mobile() {
+    return ListView(
+      padding: const EdgeInsets.all(mobilePadding),
+      children: const [],
+    );
+  }
+
+  Widget desktop() {
+    return ListView(
+      padding: const EdgeInsets.all(desktopPadding),
+      children: const [],
+    );
+  }
+}
+
+// _HomeScreenGuest shows the guest version of the home screen.
+class _HomeScreenGuest extends StatelessWidget {
+  static const double mobilePadding = 10;
+  static const double desktopPadding = 20;
+  static const double desktopMargin = 100;
+
+  const _HomeScreenGuest();
 
   @override
   Widget build(BuildContext context) {
     return ScreenTemplate(
-      ListView(
-        padding: const EdgeInsets.all(20),
-        children: [
-          Container(
-            decoration: BoxDecoration(
-              border: Border.all(color: Colors.black),
+      ResponsiveBreakpoints.of(context).isMobile
+          ? mobile(context)
+          : desktop(context),
+    );
+  }
+
+  Widget mobile(BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.all(mobilePadding),
+      children: const [
+        _WelcomeBanner(true),
+      ],
+    );
+  }
+
+  Widget desktop(BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.symmetric(vertical: desktopPadding),
+      children: const [
+        _WelcomeBanner(false),
+      ],
+    );
+  }
+}
+
+// _WelcomeBanner is applicable only to the guest home screen.
+class _WelcomeBanner extends StatelessWidget {
+  static const String bannerText =
+      "Welcome to Online Attendance Management System!";
+  static const double buttonRadius = 5;
+  static const String buttonText = "Get started";
+
+  static const double desktopPadding = 20;
+  static const double desktopMargin = 100;
+  static const double desktopButtonVerticalPadding = 30;
+  static const double desktopButtonHorizontalPadding = 20;
+  static const double desktopButtonFontSize = 24;
+
+  final bool isMobile;
+
+  const _WelcomeBanner(this.isMobile);
+
+  @override
+  Widget build(BuildContext context) {
+    return isMobile ? mobile(context) : desktop(context);
+  }
+
+  Widget mobile(BuildContext context) {
+    return const Placeholder();
+  }
+
+  Widget desktop(BuildContext context) {
+    return Card(
+      child: Container(
+        padding: const EdgeInsets.all(desktopPadding),
+        margin: const EdgeInsets.symmetric(vertical: desktopMargin),
+        alignment: Alignment.center,
+        child: Column(
+          children: [
+            Text(
+              bannerText,
+              style: Theme.of(context)
+                  .textTheme
+                  .headlineLarge
+                  ?.copyWith(fontWeight: FontWeight.bold),
+              textAlign: TextAlign.center,
             ),
-            height: 300,
-            child:
-                const Text("Welcome to Online Attendance Management System!"),
-          ),
-        ],
+            const SizedBox(height: desktopPadding),
+            FilledButton(
+              onPressed: () => context.goNamed(Routes.login.name),
+              style: FilledButton.styleFrom(
+                padding: const EdgeInsets.symmetric(
+                  vertical: desktopButtonVerticalPadding,
+                  horizontal: desktopButtonHorizontalPadding,
+                ),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(buttonRadius),
+                ),
+                textStyle: const TextStyle(fontSize: desktopButtonFontSize),
+              ),
+              child: const Text(buttonText),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/frontend/lib/screens/login_screen.dart
+++ b/frontend/lib/screens/login_screen.dart
@@ -11,9 +11,9 @@ class LoginScreen extends StatelessWidget {
   static const String buttonText = "SSO with Microsoft";
   static const String urlLaunchMode = "_self";
 
-  final String returnTo;
+  final String redirectUrl;
 
-  const LoginScreen({Key? key, this.returnTo = ""}) : super(key: key);
+  const LoginScreen({Key? key, this.redirectUrl = ""}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -46,9 +46,8 @@ class LoginScreen extends StatelessWidget {
   }
 
   Future<void> loginAction() async {
-    final redirectUrl = await APIClient.getLoginURL(returnTo);
-    if (!await launchUrl(Uri.parse(redirectUrl),
-        webOnlyWindowName: urlLaunchMode)) {
+    final url = await APIClient.getLoginURL(redirectUrl);
+    if (!await launchUrl(Uri.parse(url), webOnlyWindowName: urlLaunchMode)) {
       // TODO: Add handling here.
     }
   }

--- a/frontend/lib/screens/profile_screen.dart
+++ b/frontend/lib/screens/profile_screen.dart
@@ -58,8 +58,7 @@ class _Name extends StatelessWidget {
   final bool isMobile;
   final String name;
 
-  const _Name(this.isMobile, this.name, {Key? key})
-      : super(key: key);
+  const _Name(this.isMobile, this.name, {Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/frontend/lib/widgets/centered_view.dart
+++ b/frontend/lib/widgets/centered_view.dart
@@ -7,7 +7,7 @@ class CenteredView extends StatelessWidget {
   static const double mobileVerticalPadding = 5;
   static const double desktopHorizontalPadding = 20;
   static const double desktopVerticalPadding = 10;
-  static const double desktopMaxWidth = 1100;
+  static const double desktopMaxWidth = 1500;
 
   final Widget child;
 

--- a/frontend/lib/widgets/nav_bar.dart
+++ b/frontend/lib/widgets/nav_bar.dart
@@ -22,10 +22,12 @@ class NavBar extends StatelessWidget {
       child: Container(
         padding: const EdgeInsets.all(padding),
         decoration: BoxDecoration(
-            color: Theme.of(context).primaryColorLight,
-            boxShadow: boxShadow,
-            borderRadius:
-                const BorderRadius.all(Radius.circular(borderRadius))),
+          color: Theme.of(context).primaryColorLight,
+          boxShadow: boxShadow,
+          borderRadius: const BorderRadius.all(
+            Radius.circular(borderRadius),
+          ),
+        ),
         child: ResponsiveBreakpoints.of(context).isMobile
             ? mobile(context)
             : desktop(context),

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -92,10 +92,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: "1531542666c2d052c44bbf6e2b48011bf3771da0404b94c60eabec1228a62906"
+      sha256: edbceb4c06758652fc9d12e58edb371cd977011b032e298dae0eb357167baad2
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.0"
+    version: "9.1.1"
   http:
     dependency: "direct main"
     description:
@@ -172,10 +172,10 @@ packages:
     dependency: transitive
     description:
       name: plugin_platform_interface
-      sha256: "6a2128648c854906c53fa8e33986fc0247a1116122f9534dd20e3ab9e16a32bc"
+      sha256: "43798d895c929056255600343db8f049921cbec94d31ec87f1dc5c16c01935dd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.5"
   responsive_framework:
     dependency: "direct main"
     description:
@@ -265,18 +265,18 @@ packages:
     dependency: "direct main"
     description:
       name: url_launcher
-      sha256: eb1e00ab44303d50dd487aab67ebc575456c146c6af44422f9c13889984c00f3
+      sha256: "781bd58a1eb16069412365c98597726cd8810ae27435f04b3b4d3a470bacd61e"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.11"
+    version: "6.1.12"
   url_launcher_android:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "15f5acbf0dce90146a0f5a2c4a002b1814a6303c4c5c075aa2623b2d16156f03"
+      sha256: "78cb6dea3e93148615109e58e42c35d1ffbf5ef66c44add673d0ab75f12ff3af"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.36"
+    version: "6.0.37"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -297,10 +297,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_macos
-      sha256: "91ee3e75ea9dadf38036200c5d3743518f4a5eb77a8d13fda1ee5764373f185e"
+      sha256: "1c4fdc0bfea61a70792ce97157e5cc17260f61abbe4f39354513f39ec6fd73b1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.6"
   url_launcher_platform_interface:
     dependency: transitive
     description:
@@ -313,18 +313,18 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: "6bb1e5d7fe53daf02a8fee85352432a40b1f868a81880e99ec7440113d5cfcab"
+      sha256: cc26720eefe98c1b71d85f9dc7ef0cada5132617046369d9dc296b3ecaa5cbb4
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.17"
+    version: "2.0.18"
   url_launcher_windows:
     dependency: transitive
     description:
       name: url_launcher_windows
-      sha256: "254708f17f7c20a9c8c471f67d86d76d4a3f9c1591aad1e15292008aceb82771"
+      sha256: "7967065dd2b5fccc18c653b97958fdf839c5478c28e767c61ee879f4e7882422"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.6"
+    version: "3.0.7"
   vector_math:
     dependency: transitive
     description:
@@ -335,4 +335,4 @@ packages:
     version: "2.1.4"
 sdks:
   dart: ">=3.0.1 <4.0.0"
-  flutter: ">=3.7.0"
+  flutter: ">=3.10.0"

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -35,9 +35,9 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
-  go_router: ^9.0.0
+  go_router: ^9.1.1
   http: ^1.1.0
-  url_launcher: ^6.1.11
+  url_launcher: ^6.1.12
   responsive_framework: ^1.0.0
   flutter_riverpod: ^2.3.6
 


### PR DESCRIPTION
## Issue
We are currently using a placeholder welcome banner on the guest home screen. We should have a nicer implementation.

## Describe this PR

1. Implement the welcome banner for the guest home screen for desktop.
2. Update flutter packages.
3. Set endpoints to require auth on the api.

## Test Plan

```go test ./...```

New guest home screen:
![image](https://github.com/darylhjd/oams/assets/53652695/af827ef2-d942-4958-9389-b86ff769be96)

## Rollback Plan
Revert the PR.