### PR TITLE
feat: implement class group sessions get

### DIFF
--- a/backend/internal/tests/database_stub.go
+++ b/backend/internal/tests/database_stub.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/darylhjd/oams/backend/internal/database"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 // StubAuthContextUser inserts the mock auth context user into the database.
@@ -73,4 +74,26 @@ func StubClassGroup(t *testing.T, ctx context.Context, q *database.Queries, name
 	}
 
 	return group
+}
+
+// StubClassGroupSession inserts a mock class, class group and corresponding class group session into the database.
+func StubClassGroupSession(t *testing.T, ctx context.Context, q *database.Queries, startTime, endTime pgtype.Timestamp, venue string) database.CreateClassGroupSessionRow {
+	t.Helper()
+
+	classGroup := StubClassGroup(t, ctx, q, uuid.NewString(), database.ClassTypeLEC)
+
+	startTime.Time = startTime.Time.UTC()
+	endTime.Time = endTime.Time.UTC()
+
+	session, err := q.CreateClassGroupSession(ctx, database.CreateClassGroupSessionParams{
+		ClassGroupID: classGroup.ID,
+		StartTime:    startTime,
+		EndTime:      endTime,
+		Venue:        venue,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return session
 }

--- a/backend/servers/apiserver/v1/class_group_sessions.go
+++ b/backend/servers/apiserver/v1/class_group_sessions.go
@@ -1,13 +1,17 @@
 package v1
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/darylhjd/oams/backend/internal/database"
+)
 
 func (v *APIServerV1) classGroupSessions(w http.ResponseWriter, r *http.Request) {
 	var resp apiResponse
 
 	switch r.Method {
 	case http.MethodGet:
-		resp = newErrorResponse(http.StatusNotImplemented, "")
+		resp = v.classGroupSessionsGet(r)
 	case http.MethodPost:
 		resp = newErrorResponse(http.StatusNotImplemented, "")
 	default:
@@ -15,4 +19,24 @@ func (v *APIServerV1) classGroupSessions(w http.ResponseWriter, r *http.Request)
 	}
 
 	v.writeResponse(w, classGroupSessionsUrl, resp)
+}
+
+type classGroupSessionsGetResponse struct {
+	response
+	ClassGroupSessions []database.ClassGroupSession `json:"class_group_sessions"`
+}
+
+func (v *APIServerV1) classGroupSessionsGet(r *http.Request) apiResponse {
+	sessions, err := v.db.Q.ListClassGroupSessions(r.Context())
+	if err != nil {
+		return newErrorResponse(http.StatusInternalServerError, "could not process class group sessions get database action")
+	}
+
+	resp := classGroupSessionsGetResponse{
+		newSuccessResponse(),
+		make([]database.ClassGroupSession, 0, len(sessions)),
+	}
+
+	resp.ClassGroupSessions = append(resp.ClassGroupSessions, sessions...)
+	return resp
 }

--- a/backend/servers/apiserver/v1/class_group_sessions_test.go
+++ b/backend/servers/apiserver/v1/class_group_sessions_test.go
@@ -1,12 +1,16 @@
 package v1
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/darylhjd/oams/backend/internal/database"
 	"github.com/darylhjd/oams/backend/internal/tests"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -21,7 +25,7 @@ func TestAPIServerV1_classGroupSessions(t *testing.T) {
 		{
 			"with GET method",
 			http.MethodGet,
-			http.StatusNotImplemented,
+			http.StatusOK,
 		},
 		{
 			"with POST method",
@@ -51,6 +55,69 @@ func TestAPIServerV1_classGroupSessions(t *testing.T) {
 			v1.classGroupSessions(rr, req)
 
 			a.Equal(tt.wantStatusCode, rr.Code)
+		})
+	}
+}
+
+func TestAPIServerV1_classGroupSessionsGet(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name                          string
+		withExistingClassGroupSession bool
+		wantResponse                  classGroupSessionsGetResponse
+	}{
+		{
+			"request with class group session in database",
+			true,
+			classGroupSessionsGetResponse{
+				newSuccessResponse(),
+				[]database.ClassGroupSession{
+					{
+						StartTime: pgtype.Timestamp{Time: time.Now(), Valid: true},
+						EndTime:   pgtype.Timestamp{Time: time.Now(), Valid: true},
+						Venue:     "CLASS+22",
+					},
+				},
+			},
+		},
+		{
+			"request with no class group session in database",
+			false,
+			classGroupSessionsGetResponse{
+				newSuccessResponse(),
+				[]database.ClassGroupSession{},
+			},
+		},
+	}
+
+	for _, tt := range tts {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := assert.New(t)
+			ctx := context.Background()
+			id := uuid.NewString()
+
+			v1 := newTestAPIServerV1(t, id)
+			defer tests.TearDown(t, v1.db, id)
+
+			if tt.withExistingClassGroupSession {
+				for idx, session := range tt.wantResponse.ClassGroupSessions {
+					createdSession := tests.StubClassGroupSession(t, ctx, v1.db.Q, session.StartTime, session.EndTime, session.Venue)
+					sessionPtr := &tt.wantResponse.ClassGroupSessions[idx]
+					sessionPtr.ID = createdSession.ID
+					sessionPtr.ClassGroupID = createdSession.ClassGroupID
+					sessionPtr.StartTime, sessionPtr.EndTime = createdSession.StartTime, createdSession.EndTime
+					sessionPtr.CreatedAt, sessionPtr.UpdatedAt = createdSession.CreatedAt, createdSession.CreatedAt
+				}
+			}
+
+			req := httptest.NewRequest(http.MethodGet, classGroupSessionsUrl, nil)
+			actualResp, ok := v1.classGroupSessionsGet(req).(classGroupSessionsGetResponse)
+			a.True(ok)
+			a.Equal(tt.wantResponse, actualResp)
 		})
 	}
 }


### PR DESCRIPTION
## Issue

Implement. 

Note that the PostgreSQL schema does not store timestamp. This is a message and note to self that all time that is going to be stored in the database should first be converted to UTC time.

## Describe this PR

1. Implement.

## Test Plan

```go test ./...```

## Rollback Plan
Revert the PR.