### PR TITLE
chore: do not abuse namespace usage

### DIFF
--- a/backend/internal/database/connect.go
+++ b/backend/internal/database/connect.go
@@ -11,6 +11,10 @@ import (
 )
 
 const (
+	connectionNamespace = "database/connection"
+)
+
+const (
 	sslMode     = "sslmode"
 	sslRootCert = "sslrootcert"
 )
@@ -37,12 +41,12 @@ func ConnectDB(ctx context.Context, dbName string) (*DB, error) {
 
 	pool, err := pgxpool.New(ctx, connString)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%s - error creating connection pool: %w", connectionNamespace, err)
 	}
 
 	// Check that connection is successful.
 	if err = pool.Ping(ctx); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%s - could not ping database connection: %w", connectionNamespace, err)
 	}
 
 	return &DB{pool, New(pool)}, nil

--- a/backend/internal/env/configuration.go
+++ b/backend/internal/env/configuration.go
@@ -1,7 +1,6 @@
 package env
 
 import (
-	"errors"
 	"fmt"
 	"os"
 )
@@ -18,8 +17,8 @@ const (
 	ConfigurationDatabase  = "database"
 )
 
-// GetConfiguration returns the CONFIGURATION environment variable.
-func GetConfiguration() Configuration {
+// getConfiguration returns the CONFIGURATION environment variable.
+func getConfiguration() Configuration {
 	return Configuration(os.Getenv(configuration))
 }
 
@@ -35,13 +34,12 @@ func verifyApiServerConfiguration() error {
 		webServerPort,
 	}
 
-	baseErr := fmt.Errorf("%s - configuration verification failed for %s", namespace, ConfigurationApiServer)
 	if err := checkRequiredEnvs(envs...); err != nil {
-		return errors.Join(baseErr, err)
+		return err
 	}
 
 	if err := verifyDatabaseConfiguration(); err != nil {
-		return errors.Join(baseErr, err)
+		return err
 	}
 
 	return nil
@@ -52,13 +50,12 @@ func verifyWebServerConfiguration() error {
 		webServerPort,
 	}
 
-	baseErr := fmt.Errorf("%s - configuration verification failed for %s", namespace, ConfigurationWebServer)
 	if err := checkRequiredEnvs(envs...); err != nil {
-		return errors.Join(baseErr, err)
+		return err
 	}
 
 	if err := verifyDatabaseConfiguration(); err != nil {
-		return errors.Join(baseErr, err)
+		return err
 	}
 
 	return nil
@@ -75,9 +72,8 @@ func verifyDatabaseConfiguration() error {
 		databaseSslMode,
 	}
 
-	baseErr := fmt.Errorf("%s - configuration verification failed for %s", namespace, ConfigurationDatabase)
 	if err := checkRequiredEnvs(envs...); err != nil {
-		return errors.Join(baseErr, err)
+		return err
 	}
 
 	// Check SSL mode and root cert.
@@ -86,14 +82,12 @@ func verifyDatabaseConfiguration() error {
 	switch mode {
 	case databaseSslModeDisable:
 		if env == AppEnvStaging {
-			disabledErr := fmt.Errorf("database connection ssl mode disabled for critical environment %q", env)
-			return errors.Join(baseErr, disabledErr)
+			return fmt.Errorf("database connection ssl mode disabled for critical environment %q", env)
 		}
 		fallthrough
 	case databaseSslModeVerifyFull:
 		return nil
 	default:
-		invalidErr := fmt.Errorf("invalid %s value %q", databaseSslMode, mode)
-		return errors.Join(baseErr, invalidErr)
+		return fmt.Errorf("invalid %s value %q", databaseSslMode, mode)
 	}
 }

--- a/backend/internal/middleware/middleware.go
+++ b/backend/internal/middleware/middleware.go
@@ -91,7 +91,7 @@ func WithAuthContext(handlerFunc http.HandlerFunc, authenticator oauth2.Authenti
 		// Instead, a zero-value Account is returned, so we check that.
 		acct, err := authenticator.Account(r.Context(), c.Value)
 		if err != nil || acct.IsZero() {
-			http.Error(w, fmt.Sprintf("%s - account not found in session cache", namespace), http.StatusUnauthorized)
+			http.Error(w, "account not found in session cache", http.StatusUnauthorized)
 			return
 		}
 

--- a/backend/servers/apiserver/common/batch_data.go
+++ b/backend/servers/apiserver/common/batch_data.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -36,16 +37,16 @@ type SessionData struct {
 // IsValid is a helper function to check if a BatchData is valid and returns an error if it is not.
 func (c *BatchData) IsValid() error {
 	if len(c.ClassGroups) == 0 {
-		return fmt.Errorf("%s - creation data has no valid class groups", namespace)
+		return errors.New("creation data has no valid class groups")
 	}
 
 	for _, classGroup := range c.ClassGroups {
 		if len(classGroup.Sessions) == 0 {
-			return fmt.Errorf("%s - class group %s has no sessions", namespace, classGroup.Name)
+			return fmt.Errorf("class group %s has no sessions", classGroup.Name)
 		}
 
 		if len(classGroup.Students) == 0 {
-			return fmt.Errorf("%s - class group %s has no enrollments", namespace, classGroup.Name)
+			return fmt.Errorf("class group %s has no enrollments", classGroup.Name)
 		}
 	}
 

--- a/backend/servers/apiserver/v1/base.go
+++ b/backend/servers/apiserver/v1/base.go
@@ -9,7 +9,6 @@ type baseResponse struct {
 	Message string `json:"message"`
 }
 
-// base is the handler for the baseUrl.
 func (v *APIServerV1) base(w http.ResponseWriter, r *http.Request) {
 	var resp apiResponse
 


### PR DESCRIPTION
## Issue

Currently, there is not fixed convention on the usage of the namespace. Ideally, we do not want to expose this value to users, so we only usually use this for internal logging.

## Describe this PR

1. Reduce namespace abuse for errors.
2. For public methods, we usually add a namespace to the error so we can clearly see where errors occur, but on private methods, the error is bubbled up and not wrapped with the namespace.

## Test Plan

```go test ./...```

## Rollback Plan
Revert the PR.