### PR TITLE
feat: add `attended` column to session enrollments to track attendance

### DIFF
--- a/backend/internal/database/config/migrations/000001_initial.up.sql
+++ b/backend/internal/database/config/migrations/000001_initial.up.sql
@@ -65,6 +65,7 @@ CREATE TABLE session_enrollments
 (
     session_id BIGINT    NOT NULL,
     user_id    TEXT      NOT NULL,
+    attended   BOOLEAN   NOT NULL,
     created_at TIMESTAMP NOT NULL,
     PRIMARY KEY (session_id, user_id),
     CONSTRAINT fk_session_id

--- a/backend/internal/database/config/session_enrollments.sql
+++ b/backend/internal/database/config/session_enrollments.sql
@@ -14,6 +14,6 @@ FROM session_enrollments
 WHERE user_id = $1;
 
 -- name: CreateSessionEnrollments :batchone
-INSERT INTO session_enrollments (session_id, user_id, created_at)
-VALUES ($1, $2, NOW())
+INSERT INTO session_enrollments (session_id, user_id, attended, created_at)
+VALUES ($1, $2, $3, NOW())
 RETURNING *;

--- a/backend/internal/database/models.go
+++ b/backend/internal/database/models.go
@@ -130,6 +130,7 @@ type ClassGroupSession struct {
 type SessionEnrollment struct {
 	SessionID int64            `json:"session_id"`
 	UserID    string           `json:"user_id"`
+	Attended  bool             `json:"attended"`
 	CreatedAt pgtype.Timestamp `json:"created_at"`
 }
 

--- a/backend/internal/database/session_enrollments.sql.go
+++ b/backend/internal/database/session_enrollments.sql.go
@@ -10,7 +10,7 @@ import (
 )
 
 const getSessionEnrollmentsBySessionID = `-- name: GetSessionEnrollmentsBySessionID :many
-SELECT session_id, user_id, created_at
+SELECT session_id, user_id, attended, created_at
 FROM session_enrollments
 WHERE session_id = $1
 `
@@ -24,7 +24,12 @@ func (q *Queries) GetSessionEnrollmentsBySessionID(ctx context.Context, sessionI
 	var items []SessionEnrollment
 	for rows.Next() {
 		var i SessionEnrollment
-		if err := rows.Scan(&i.SessionID, &i.UserID, &i.CreatedAt); err != nil {
+		if err := rows.Scan(
+			&i.SessionID,
+			&i.UserID,
+			&i.Attended,
+			&i.CreatedAt,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, i)
@@ -36,7 +41,7 @@ func (q *Queries) GetSessionEnrollmentsBySessionID(ctx context.Context, sessionI
 }
 
 const getSessionEnrollmentsByUserID = `-- name: GetSessionEnrollmentsByUserID :many
-SELECT session_id, user_id, created_at
+SELECT session_id, user_id, attended, created_at
 FROM session_enrollments
 WHERE user_id = $1
 `
@@ -50,7 +55,12 @@ func (q *Queries) GetSessionEnrollmentsByUserID(ctx context.Context, userID stri
 	var items []SessionEnrollment
 	for rows.Next() {
 		var i SessionEnrollment
-		if err := rows.Scan(&i.SessionID, &i.UserID, &i.CreatedAt); err != nil {
+		if err := rows.Scan(
+			&i.SessionID,
+			&i.UserID,
+			&i.Attended,
+			&i.CreatedAt,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, i)
@@ -62,7 +72,7 @@ func (q *Queries) GetSessionEnrollmentsByUserID(ctx context.Context, userID stri
 }
 
 const listSessionEnrollments = `-- name: ListSessionEnrollments :many
-SELECT session_id, user_id, created_at
+SELECT session_id, user_id, attended, created_at
 FROM session_enrollments
 ORDER BY session_id, user_id
 `
@@ -76,7 +86,12 @@ func (q *Queries) ListSessionEnrollments(ctx context.Context) ([]SessionEnrollme
 	var items []SessionEnrollment
 	for rows.Next() {
 		var i SessionEnrollment
-		if err := rows.Scan(&i.SessionID, &i.UserID, &i.CreatedAt); err != nil {
+		if err := rows.Scan(
+			&i.SessionID,
+			&i.UserID,
+			&i.Attended,
+			&i.CreatedAt,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/backend/servers/apiserver/v1/batch.go
+++ b/backend/servers/apiserver/v1/batch.go
@@ -266,8 +266,9 @@ func (v *APIServerV1) processBatchPostRequest(ctx context.Context, req batchPost
 		for idx := range classGroupSessionsHelper.students[i] {
 			studentsParams = append(studentsParams, classGroupSessionsHelper.students[i][idx])
 			enrollmentsParams = append(enrollmentsParams, database.CreateSessionEnrollmentsParams{
-				SessionID: session.ID,
-				UserID:    classGroupSessionsHelper.students[i][idx].ID,
+				session.ID,
+				classGroupSessionsHelper.students[i][idx].ID,
+				false,
 			})
 		}
 	})


### PR DESCRIPTION
## Issue

Currently, the `session_enrollments` table only stores enrollments, but it does not store information on whether a particular student did or did not attend a particular session.

We can add a column called `attended` to fix this.

## Describe this PR

1. Add the column.

## Test Plan

```go test ./...```

## Rollback Plan
Revert the PR.