### PR TITLE
chore: add id for session enrollments

### DIFF
--- a/backend/internal/database/batch.go
+++ b/backend/internal/database/batch.go
@@ -20,7 +20,7 @@ var (
 const createSessionEnrollments = `-- name: CreateSessionEnrollments :batchone
 INSERT INTO session_enrollments (session_id, user_id, attended, created_at)
 VALUES ($1, $2, $3, NOW())
-RETURNING session_id, user_id, attended, created_at
+RETURNING id, session_id, user_id, attended, created_at
 `
 
 type CreateSessionEnrollmentsBatchResults struct {
@@ -61,6 +61,7 @@ func (b *CreateSessionEnrollmentsBatchResults) QueryRow(f func(int, SessionEnrol
 		}
 		row := b.br.QueryRow()
 		err := row.Scan(
+			&i.ID,
 			&i.SessionID,
 			&i.UserID,
 			&i.Attended,

--- a/backend/internal/database/config/migrations/000001_initial.up.sql
+++ b/backend/internal/database/config/migrations/000001_initial.up.sql
@@ -63,11 +63,13 @@ CREATE TABLE class_group_sessions
 
 CREATE TABLE session_enrollments
 (
+    id         BIGSERIAL PRIMARY KEY,
     session_id BIGINT    NOT NULL,
     user_id    TEXT      NOT NULL,
     attended   BOOLEAN   NOT NULL,
     created_at TIMESTAMP NOT NULL,
-    PRIMARY KEY (session_id, user_id),
+    CONSTRAINT ux_session_id_user_id
+        UNIQUE (session_id, user_id),
     CONSTRAINT fk_session_id
         FOREIGN KEY (session_id)
             REFERENCES class_group_sessions (id),

--- a/backend/internal/database/config/session_enrollments.sql
+++ b/backend/internal/database/config/session_enrollments.sql
@@ -3,6 +3,12 @@ SELECT *
 FROM session_enrollments
 ORDER BY session_id, user_id;
 
+-- name: GetSessionEnrollment :one
+SELECT *
+FROM session_enrollments
+WHERE id = $1
+LIMIT 1;
+
 -- name: GetSessionEnrollmentsBySessionID :many
 SELECT *
 FROM session_enrollments

--- a/backend/internal/database/models.go
+++ b/backend/internal/database/models.go
@@ -128,6 +128,7 @@ type ClassGroupSession struct {
 }
 
 type SessionEnrollment struct {
+	ID        int64            `json:"id"`
 	SessionID int64            `json:"session_id"`
 	UserID    string           `json:"user_id"`
 	Attended  bool             `json:"attended"`

--- a/backend/internal/database/session_enrollments.sql.go
+++ b/backend/internal/database/session_enrollments.sql.go
@@ -9,8 +9,28 @@ import (
 	"context"
 )
 
+const getSessionEnrollment = `-- name: GetSessionEnrollment :one
+SELECT id, session_id, user_id, attended, created_at
+FROM session_enrollments
+WHERE id = $1
+LIMIT 1
+`
+
+func (q *Queries) GetSessionEnrollment(ctx context.Context, id int64) (SessionEnrollment, error) {
+	row := q.db.QueryRow(ctx, getSessionEnrollment, id)
+	var i SessionEnrollment
+	err := row.Scan(
+		&i.ID,
+		&i.SessionID,
+		&i.UserID,
+		&i.Attended,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
 const getSessionEnrollmentsBySessionID = `-- name: GetSessionEnrollmentsBySessionID :many
-SELECT session_id, user_id, attended, created_at
+SELECT id, session_id, user_id, attended, created_at
 FROM session_enrollments
 WHERE session_id = $1
 `
@@ -25,6 +45,7 @@ func (q *Queries) GetSessionEnrollmentsBySessionID(ctx context.Context, sessionI
 	for rows.Next() {
 		var i SessionEnrollment
 		if err := rows.Scan(
+			&i.ID,
 			&i.SessionID,
 			&i.UserID,
 			&i.Attended,
@@ -41,7 +62,7 @@ func (q *Queries) GetSessionEnrollmentsBySessionID(ctx context.Context, sessionI
 }
 
 const getSessionEnrollmentsByUserID = `-- name: GetSessionEnrollmentsByUserID :many
-SELECT session_id, user_id, attended, created_at
+SELECT id, session_id, user_id, attended, created_at
 FROM session_enrollments
 WHERE user_id = $1
 `
@@ -56,6 +77,7 @@ func (q *Queries) GetSessionEnrollmentsByUserID(ctx context.Context, userID stri
 	for rows.Next() {
 		var i SessionEnrollment
 		if err := rows.Scan(
+			&i.ID,
 			&i.SessionID,
 			&i.UserID,
 			&i.Attended,
@@ -72,7 +94,7 @@ func (q *Queries) GetSessionEnrollmentsByUserID(ctx context.Context, userID stri
 }
 
 const listSessionEnrollments = `-- name: ListSessionEnrollments :many
-SELECT session_id, user_id, attended, created_at
+SELECT id, session_id, user_id, attended, created_at
 FROM session_enrollments
 ORDER BY session_id, user_id
 `
@@ -87,6 +109,7 @@ func (q *Queries) ListSessionEnrollments(ctx context.Context) ([]SessionEnrollme
 	for rows.Next() {
 		var i SessionEnrollment
 		if err := rows.Scan(
+			&i.ID,
 			&i.SessionID,
 			&i.UserID,
 			&i.Attended,


### PR DESCRIPTION
## Issue

Currently, a session enrollment entry is uniquely identified by the session and user id tuple. We want to add a `id` column that uniquely identifies a tuple using only one column.

## Describe this PR

1. Add the `id` column to the `session_enrollments` table.

## Test Plan

```go test ./...```

## Rollback Plan
Revert the PR.