### PR TITLE
refactor: make class_type part of class group uniqueness

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ location in the `.env` file. Otherwise, you will not be able to successfully con
 The frontend is built on Flutter.
 
 The `frontend` module requires its own set of environment variables that is defined separately from the `backend` module.
-Refer to the `env.example.json` file for details on the formatting of the file formatting and values required.
+Refer to the `env.example.json` file for details on the formatting of the file and values required.
 
 As always, the recommendation is to use a proper IDE that can help you set up the environment variables before running any
 build or run commands. For your information, you can use the `--dart-define-from-file=env.json` argument with `flutter`

--- a/backend/internal/database/batch.go
+++ b/backend/internal/database/batch.go
@@ -97,14 +97,7 @@ func (b *UpsertClassGroupSessionsBatchResults) Close() error {
 const upsertClassGroups = `-- name: UpsertClassGroups :batchone
 INSERT INTO class_groups (class_id, name, class_type, created_at, updated_at)
 VALUES ($1, $2, $3, NOW(), NOW())
-ON CONFLICT ON CONSTRAINT ux_class_id_name
-    DO UPDATE SET class_type = $3,
-                  updated_at =
-                      CASE
-                          WHEN $3 <> class_groups.class_type
-                              THEN NOW()
-                          ELSE class_groups.updated_at
-                          END
+ON CONFLICT DO NOTHING
 RETURNING id, class_id, name, class_type, created_at, updated_at
 `
 
@@ -120,7 +113,7 @@ type UpsertClassGroupsParams struct {
 	ClassType ClassType `json:"class_type"`
 }
 
-// Insert a class group into the database. If the class group already exists, only update the class type.
+// Insert a class group into the database. If the class group already exists, do nothing.
 func (q *Queries) UpsertClassGroups(ctx context.Context, arg []UpsertClassGroupsParams) *UpsertClassGroupsBatchResults {
 	batch := &pgx.Batch{}
 	for _, a := range arg {

--- a/backend/internal/database/config/class_groups.sql
+++ b/backend/internal/database/config/class_groups.sql
@@ -42,15 +42,8 @@ WHERE id = $1
 RETURNING *;
 
 -- name: UpsertClassGroups :batchone
--- Insert a class group into the database. If the class group already exists, only update the class type.
+-- Insert a class group into the database. If the class group already exists, do nothing.
 INSERT INTO class_groups (class_id, name, class_type, created_at, updated_at)
 VALUES ($1, $2, $3, NOW(), NOW())
-ON CONFLICT ON CONSTRAINT ux_class_id_name
-    DO UPDATE SET class_type = $3,
-                  updated_at =
-                      CASE
-                          WHEN $3 <> class_groups.class_type
-                              THEN NOW()
-                          ELSE class_groups.updated_at
-                          END
+ON CONFLICT DO NOTHING
 RETURNING *;

--- a/backend/internal/database/config/migrations/000001_initial.up.sql
+++ b/backend/internal/database/config/migrations/000001_initial.up.sql
@@ -36,8 +36,8 @@ CREATE TABLE class_groups
     class_type CLASS_TYPE  NOT NULL,
     created_at TIMESTAMPTZ NOT NULL,
     updated_at TIMESTAMPTZ NOT NULL,
-    CONSTRAINT ux_class_id_name
-        UNIQUE (class_id, name),
+    CONSTRAINT ux_class_id_name_class_type
+        UNIQUE (class_id, name, class_type),
     CONSTRAINT fk_class_id
         FOREIGN KEY (class_id)
             REFERENCES classes (id)

--- a/backend/internal/servers/apiserver/v1/class_group.go
+++ b/backend/internal/servers/apiserver/v1/class_group.go
@@ -104,7 +104,7 @@ func (v *APIServerV1) classGroupPatch(r *http.Request, id int64) apiResponse {
 		case database.ErrSQLState(err, database.SQLStateForeignKeyViolation):
 			return newErrorResponse(http.StatusBadRequest, "class_id does not exist")
 		case database.ErrSQLState(err, database.SQLStateDuplicateKeyOrIndex):
-			return newErrorResponse(http.StatusConflict, "class group with same class_id and name already exists")
+			return newErrorResponse(http.StatusConflict, "class group with same class_id, name, and class_type already exists")
 		default:
 			v.logInternalServerError(r, err)
 			return newErrorResponse(http.StatusInternalServerError, "could not process class group patch database action")

--- a/backend/internal/servers/apiserver/v1/class_group_test.go
+++ b/backend/internal/servers/apiserver/v1/class_group_test.go
@@ -225,7 +225,7 @@ func TestAPIServerV1_classGroupPatch(t *testing.T) {
 			classGroupPatchResponse{},
 			false,
 			http.StatusConflict,
-			"class group with same class_id and name already exists",
+			"class group with same class_id, name, and class_type already exists",
 		},
 		{
 			"request with non existent class dependency",

--- a/backend/internal/servers/apiserver/v1/class_groups.go
+++ b/backend/internal/servers/apiserver/v1/class_groups.go
@@ -62,7 +62,7 @@ func (v *APIServerV1) classGroupsPost(r *http.Request) apiResponse {
 	if err != nil {
 		switch {
 		case database.ErrSQLState(err, database.SQLStateDuplicateKeyOrIndex):
-			return newErrorResponse(http.StatusConflict, "class group with same class_id and name already exists")
+			return newErrorResponse(http.StatusConflict, "class group with same class_id, name, and class_type already exists")
 		case database.ErrSQLState(err, database.SQLStateForeignKeyViolation):
 			return newErrorResponse(http.StatusBadRequest, "class_id does not exist")
 		default:

--- a/backend/internal/servers/apiserver/v1/class_groups_test.go
+++ b/backend/internal/servers/apiserver/v1/class_groups_test.go
@@ -165,7 +165,7 @@ func TestAPIServerV1_classGroupsPost(t *testing.T) {
 			true,
 			classGroupsPostResponse{},
 			http.StatusConflict,
-			"class group with same class_id and name already exists",
+			"class group with same class_id, name, and class_type already exists",
 		},
 		{
 			"request with non-existent class dependency",

--- a/backend/internal/servers/apiserver/v1/ms_login_callback.go
+++ b/backend/internal/servers/apiserver/v1/ms_login_callback.go
@@ -46,8 +46,7 @@ func (v *APIServerV1) msLoginCallback(w http.ResponseWriter, r *http.Request) {
 		{
 			ID:    authResult.IDToken.Name,
 			Email: authResult.Account.PreferredUsername,
-			// TODO: Set correct role based on auth result.
-			Role: database.UserRoleSTUDENT,
+			Role:  database.UserRoleSTUDENT, // Basic role given to all users on first login.
 		},
 	}).Close()
 	if err != nil {


### PR DESCRIPTION
## Issue

Currently, the constraint on the class_group table covers the class_id and class group name. However, this is not enough.

Excerpt from clarification with product owner:
```
The group’s name is unique for a course within a semester.

Meaning the same group’s name may appear on:
1. Different course on the same semester
2. Same course on different semester.

The same group of students will have the same group name for both the tutorial and lab session for the same course within the semester.
```

The last sentence is important as it implies that the same group name will appear for the same class for different class_types. Therefore, if a class has lectures, tutorials, and labs, then the same (class_id, name) tuple may be allowed to appear at most 3 times in the class_groups table. Thus, a unique constraint on just (class_id, name) is wrong - it must also include class_type.

Regarding the first 2 points, this is already ensured.
1. The class_groups table pairs a group name with a class_id, and the class_id is different for different courses within the same semester.
2. The class_groups table pairs a group name with a class_id, and the class_id is different for the same courses in different semesters.

## Describe this PR

1. Add class_type into class_groups unique constraint.
2. Update tests and error messages on apiserver endpoints.
3. Update SQL statements for class_group upsert.

## Test Plan

```go test ./...```

## Rollback Plan
Revert the PR.