### PR TITLE
fix: change frontend to support user me upcoming sessions

### DIFF
--- a/backend/internal/servers/apiserver/v1/batch.go
+++ b/backend/internal/servers/apiserver/v1/batch.go
@@ -158,6 +158,7 @@ func (v *APIServerV1) batchPut(r *http.Request) apiResponse {
 
 // processBatchPutRequest and return a batchPutResponse and error if encountered.
 // This implementation aims to reduce database actions by sacrificing memory usage.
+// TODO: This endpoint returns an internal server error with rows not found message if the upsert does nothing.
 func (v *APIServerV1) processBatchPutRequest(r *http.Request, req batchPutRequest) (batchPutResponse, error) {
 	resp := batchPutResponse{
 		response: newSuccessResponse(),

--- a/frontend/lib/api/models.dart
+++ b/frontend/lib/api/models.dart
@@ -14,12 +14,15 @@ class LoginResponse {
 }
 
 class UserMeResponse {
-  final User? sessionUser;
+  final User sessionUser;
+  final List<UpcomingClassGroupSession> upcomingSessions;
 
   UserMeResponse.fromJson(Map<String, dynamic> json)
-      : sessionUser = json["session_user"] == null
-            ? null
-            : User.fromJson(json["session_user"]);
+      : sessionUser = User.fromJson(json["session_user"]),
+        upcomingSessions = List<UpcomingClassGroupSession>.from(
+          (json["upcoming_class_group_sessions"] as List)
+              .map((i) => UpcomingClassGroupSession.fromJson(i)),
+        );
 }
 
 class User {
@@ -33,6 +36,39 @@ class User {
         name = json["name"],
         email = json["email"],
         role = json["role"];
+}
+
+class UpcomingClassGroupSession {
+  final String code;
+  final int year;
+  final String semester;
+  final String name;
+  final ClassType classType;
+  final DateTime startTime;
+  final DateTime endTime;
+
+  UpcomingClassGroupSession.fromJson(Map<String, dynamic> json)
+      : code = json["code"],
+        year = json["year"],
+        semester = json["semester"],
+        name = json["name"],
+        classType = ClassType.fromValue(json["class_type"]),
+        startTime = DateTime.parse(json["start_time"]).toLocal(),
+        endTime = DateTime.parse(json["end_time"]).toLocal();
+}
+
+enum ClassType {
+  lec("LEC"),
+  tut("TUT"),
+  lab("LAB");
+
+  final String name;
+
+  const ClassType(this.name);
+
+  factory ClassType.fromValue(String value) {
+    return ClassType.values.firstWhere((e) => e.name == value);
+  }
 }
 
 class GetUserResponse {

--- a/frontend/lib/providers/session.dart
+++ b/frontend/lib/providers/session.dart
@@ -5,14 +5,11 @@ import 'package:frontend/api/models.dart';
 // Provides information about the current session use. We do this since the API
 // uses a HttpOnly cookie to store the required auth codes and so we cannot read
 // it directly.
-final sessionUserProvider = FutureProvider<User>((ref) async {
+final sessionUserProvider = FutureProvider<UserMeResponse>((ref) async {
   try {
     var resp = await APIClient.getUserMe();
-    if (resp.sessionUser == null) {
-      throw Exception("no session user");
-    }
     ref.read(sessionProvider.notifier).update((_) => true);
-    return resp.sessionUser!;
+    return resp;
   } catch (e) {
     ref.read(sessionProvider.notifier).update((_) => false);
     rethrow;

--- a/frontend/lib/screens/profile_screen.dart
+++ b/frontend/lib/screens/profile_screen.dart
@@ -28,18 +28,18 @@ class ProfileScreen extends ConsumerWidget {
     );
   }
 
-  Widget _mobile(BuildContext context, User user) {
+  Widget _mobile(BuildContext context, UserMeResponse data) {
     return ListView(
       padding: const EdgeInsets.symmetric(vertical: _mobilePadding),
       children: [
-        _NameHeader(true, user),
+        _NameHeader(true, data.sessionUser),
         const SizedBox(height: _mobilePadding),
-        _DetailsCard(true, user),
+        _DetailsCard(true, data.sessionUser),
       ],
     );
   }
 
-  Widget _desktop(BuildContext context, User user) {
+  Widget _desktop(BuildContext context, UserMeResponse data) {
     return Container(
       padding: const EdgeInsets.symmetric(vertical: _desktopPadding),
       child: Row(
@@ -48,12 +48,12 @@ class ProfileScreen extends ConsumerWidget {
         children: [
           Container(
             padding: const EdgeInsets.fromLTRB(0, 0, _desktopPadding, 0),
-            child: _NameHeader(false, user),
+            child: _NameHeader(false, data.sessionUser),
           ),
           Flexible(
             child: ListView(
               children: [
-                _DetailsCard(false, user),
+                _DetailsCard(false, data.sessionUser),
               ],
             ),
           ),


### PR DESCRIPTION
## Issue

Currently, the frontend implementation only supports getting the user session info, but not other fields from the API. We want to change this so that extra fields from the API are also parsed and can be retrieved from the provider.

## Describe this PR

1. Change implementation to support upcoming class group sessions.
2. Add TODO to batch api about error.

## Test Plan

```go test ./...```

## Rollback Plan
Revert the PR.