### PR TITLE
feat: show user details on profile page

### DIFF
--- a/frontend/lib/screens/profile_screen.dart
+++ b/frontend/lib/screens/profile_screen.dart
@@ -87,6 +87,8 @@ class _ProfileHeader extends StatelessWidget {
 
 // _DetailsCard shows the details of the user.
 class _DetailsCard extends StatelessWidget {
+  static const double _padding = 50;
+
   final User _user;
 
   const _DetailsCard(this._user);
@@ -95,7 +97,7 @@ class _DetailsCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Card(
       child: Container(
-        padding: const EdgeInsets.all(50),
+        padding: const EdgeInsets.all(_padding),
         child: Column(
           children: [
             TextFormField(


### PR DESCRIPTION
## Issue

Currently, the profile page uses a placeholder for the user details. We want to show the actual user information.

## Describe this PR

1. Implement the user details.

## Test Plan

Mobile:
![image](https://github.com/darylhjd/oams/assets/53652695/baf11dae-f5cd-4750-a77d-b3359a216276)

Desktop:
![image](https://github.com/darylhjd/oams/assets/53652695/06aa0cdb-bc66-43e5-bae2-647b3608b37b)

## Rollback Plan
Revert the PR.