### PR TITLE
feat: implement session previewer

### DIFF
--- a/frontend/lib/widgets/nav_bar.dart
+++ b/frontend/lib/widgets/nav_bar.dart
@@ -8,8 +8,9 @@ import 'package:responsive_framework/responsive_framework.dart';
 
 // The navigation bar for the app.
 class NavBar extends StatelessWidget {
-  static const double _height = 70;
-  static const double _padding = 10;
+  static const double _height = 90;
+  static const double _margin = 10;
+  static const double _padding = 5;
   static final List<BoxShadow>? _boxShadow = kElevationToShadow[8];
   static const double _borderRadius = 10;
 
@@ -20,6 +21,7 @@ class NavBar extends StatelessWidget {
     return SizedBox(
       height: _height,
       child: Container(
+        margin: const EdgeInsets.all(_margin),
         padding: const EdgeInsets.all(_padding),
         decoration: BoxDecoration(
           color: Theme.of(context).primaryColorLight,


### PR DESCRIPTION
## Issue

Currently, interacting with the calendar does nothing. 

## Describe this PR

1. Adds implementation for the previewer.
2. Also adds margin to the navbar so that the card doesn't abruptly intersect during scroll.

## Test Plan

Mobile:
![image](https://github.com/darylhjd/oams/assets/53652695/8c4f514a-0ac9-4189-a084-e65382d1d822)

Desktop:
![image](https://github.com/darylhjd/oams/assets/53652695/930b5d8a-b87c-40c5-8abf-539ea3250cb6)

## Rollback Plan
Revert the PR.