### PR TITLE
fix: nav bar margin

### DIFF
--- a/frontend/lib/screens/home_screen_guest.dart
+++ b/frontend/lib/screens/home_screen_guest.dart
@@ -213,7 +213,7 @@ class _Features extends StatelessWidget {
 
 // Provides the template for a feature showcase.
 class _FeatureCard extends StatelessWidget {
-  static const double _mobileCardMargin = 10;
+  static const double _mobileCardMargin = 5;
   static const double _mobilePadding = 10;
   static const double _mobileMargin = 20;
 
@@ -233,7 +233,7 @@ class _FeatureCard extends StatelessWidget {
 
   Widget _mobile(BuildContext context) {
     return Card(
-      margin: const EdgeInsets.symmetric(vertical: _mobileCardMargin),
+      margin: const EdgeInsets.all(_mobileCardMargin),
       child: Container(
         padding: const EdgeInsets.all(_mobilePadding),
         margin: const EdgeInsets.symmetric(vertical: _mobileMargin),

--- a/frontend/lib/widgets/nav_bar.dart
+++ b/frontend/lib/widgets/nav_bar.dart
@@ -21,7 +21,7 @@ class NavBar extends StatelessWidget {
     return SizedBox(
       height: _height,
       child: Container(
-        margin: const EdgeInsets.all(_margin),
+        margin: const EdgeInsets.symmetric(vertical: _margin),
         padding: const EdgeInsets.all(_padding),
         decoration: BoxDecoration(
           color: Theme.of(context).primaryColorLight,


### PR DESCRIPTION
## Issue

We unnecessarily added margin to the horizontal axis for the nav bar, making it look a little small.

## Describe this PR

1. Only margin on vertical axis.
2. Fix some slight padding on feature card.

## Test Plan

Navbar
![image](https://github.com/darylhjd/oams/assets/53652695/6ef9ec9e-8878-47d2-b5c0-8208f5f64323)

Mobile Padding
![image](https://github.com/darylhjd/oams/assets/53652695/e0d3f344-eb61-41d8-acdd-ddf07c96283f)

## Rollback Plan
Revert the PR.