### PR TITLE
feat: add adminpanel button

### DIFF
--- a/frontend/lib/api/models.dart
+++ b/frontend/lib/api/models.dart
@@ -29,13 +29,27 @@ class User {
   final String id;
   final String name;
   final String email;
-  final String role;
+  final UserRole role;
 
   User.fromJson(Map<String, dynamic> json)
       : id = json["id"],
         name = json["name"],
         email = json["email"],
-        role = json["role"];
+        role = UserRole.fromValue(json["role"]);
+}
+
+enum UserRole {
+  student("STUDENT"),
+  courseCoordinator("COURSE_COORDINATOR"),
+  admin("ADMIN");
+
+  final String name;
+
+  const UserRole(this.name);
+
+  factory UserRole.fromValue(String value) {
+    return UserRole.values.firstWhere((e) => e.name == value);
+  }
 }
 
 class UpcomingClassGroupSession {

--- a/frontend/lib/screens/profile_screen.dart
+++ b/frontend/lib/screens/profile_screen.dart
@@ -110,7 +110,7 @@ class _DetailsCard extends StatelessWidget {
             TextFormField(
               decoration: const InputDecoration(labelText: "Role"),
               readOnly: true,
-              initialValue: _user.role.isEmpty ? "-" : _user.role,
+              initialValue: _user.role.name,
             ),
           ],
         ),


### PR DESCRIPTION
## Issue

We want to support an admin panel implementation which is accessible from the frontend.

## Describe this PR

1. Implement the button.
2. Change role field in User model to be an enum.

## Test Plan

Mobile as admin:
![image](https://github.com/darylhjd/oams/assets/53652695/ef957beb-f730-4d98-aee1-6e2199edf8bc)

Mobile as non-admin:
![image](https://github.com/darylhjd/oams/assets/53652695/a79eb8a8-e8a6-424d-bf79-76979cb20294)

Desktop as admin:
![image](https://github.com/darylhjd/oams/assets/53652695/bc93d191-dbd2-435f-9a87-e05142502245)

Desktop as non-admin:
![image](https://github.com/darylhjd/oams/assets/53652695/c7fdd8dd-73da-451c-ae93-9f0f7694a75a)


## Rollback Plan
Revert the PR.