### PR TITLE
feat: add placeholder admin panel screen

### DIFF
--- a/frontend/lib/screens/admin_panel_screen.dart
+++ b/frontend/lib/screens/admin_panel_screen.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+import 'package:frontend/screens/screen_template.dart';
+
+class AdminPanelScreen extends StatelessWidget {
+  const AdminPanelScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const ScreenTemplate(
+      Placeholder(),
+    );
+  }
+}

--- a/frontend/lib/widgets/nav_bar.dart
+++ b/frontend/lib/widgets/nav_bar.dart
@@ -186,14 +186,15 @@ class _AdminPanelButton extends StatelessWidget {
   }
 
   Widget _mobile(BuildContext context) {
-    return const PopupMenuItem<Widget>(
+    return PopupMenuItem<Widget>(
+      onTap: () => context.goNamed(Routes.adminPanel.name),
       child: _text,
     );
   }
 
   Widget _desktop(BuildContext context) {
     return TextButton(
-      onPressed: () {},
+      onPressed: () => context.goNamed(Routes.adminPanel.name),
       child: _text,
     );
   }


### PR DESCRIPTION
## Issue

We want to support an administrative panel on the frontend.

## Describe this PR

1. Add a placeholder administrative panel.
2. Add gorouter to point towards that page.

## Test Plan

1. Check that the redirect logic works for logged in and non-logged in.
2. Check that the redirect logic works for user role (redirect to index page if not privileged enough).
3. Check that the admin panel button does not appear when user does not have proper role and vice versa.

With privilege:
![image](https://github.com/darylhjd/oams/assets/53652695/e1894fcd-3a8e-41a7-8259-05b56a0e1159)
![image](https://github.com/darylhjd/oams/assets/53652695/ac876e57-a35f-41f5-90e4-0f4b70e0b287)

## Rollback Plan
Revert the PR.