### PR TITLE
feat: add defaults for created_at and updated_at fields

### DIFF
--- a/backend/internal/database/class_group_sessions.go
+++ b/backend/internal/database/class_group_sessions.go
@@ -50,23 +50,17 @@ type CreateClassGroupSessionParams struct {
 func (d *DB) CreateClassGroupSession(ctx context.Context, arg CreateClassGroupSessionParams) (model.ClassGroupSession, error) {
 	var res model.ClassGroupSession
 
-	now := time.Now()
-
 	stmt := ClassGroupSessions.INSERT(
 		ClassGroupSessions.ClassGroupID,
 		ClassGroupSessions.StartTime,
 		ClassGroupSessions.EndTime,
 		ClassGroupSessions.Venue,
-		ClassGroupSessions.CreatedAt,
-		ClassGroupSessions.UpdatedAt,
 	).MODEL(
 		model.ClassGroupSession{
 			ClassGroupID: arg.ClassGroupID,
 			StartTime:    arg.StartTime,
 			EndTime:      arg.EndTime,
 			Venue:        arg.Venue,
-			CreatedAt:    now,
-			UpdatedAt:    now,
 		},
 	).RETURNING(
 		ClassGroupSessions.AllColumns,

--- a/backend/internal/database/class_groups.go
+++ b/backend/internal/database/class_groups.go
@@ -2,7 +2,6 @@ package database
 
 import (
 	"context"
-	"time"
 
 	"github.com/darylhjd/oams/backend/internal/database/gen/oams/public/model"
 	. "github.com/darylhjd/oams/backend/internal/database/gen/oams/public/table"
@@ -49,21 +48,15 @@ type CreateClassGroupParams struct {
 func (d *DB) CreateClassGroup(ctx context.Context, arg CreateClassGroupParams) (model.ClassGroup, error) {
 	var res model.ClassGroup
 
-	now := time.Now()
-
 	stmt := ClassGroups.INSERT(
 		ClassGroups.ClassID,
 		ClassGroups.Name,
 		ClassGroups.ClassType,
-		ClassGroups.CreatedAt,
-		ClassGroups.UpdatedAt,
 	).MODEL(
 		model.ClassGroup{
 			ClassID:   arg.ClassID,
 			Name:      arg.Name,
 			ClassType: arg.ClassType,
-			CreatedAt: now,
-			UpdatedAt: now,
 		},
 	).RETURNING(
 		ClassGroups.AllColumns,

--- a/backend/internal/database/classes.go
+++ b/backend/internal/database/classes.go
@@ -2,7 +2,6 @@ package database
 
 import (
 	"context"
-	"time"
 
 	"github.com/darylhjd/oams/backend/internal/database/gen/oams/public/model"
 	. "github.com/darylhjd/oams/backend/internal/database/gen/oams/public/table"
@@ -52,16 +51,12 @@ type CreateClassParams struct {
 func (d *DB) CreateClass(ctx context.Context, arg CreateClassParams) (model.Class, error) {
 	var res model.Class
 
-	now := time.Now()
-
 	stmt := Classes.INSERT(
 		Classes.Code,
 		Classes.Year,
 		Classes.Semester,
 		Classes.Programme,
 		Classes.Au,
-		Classes.CreatedAt,
-		Classes.UpdatedAt,
 	).MODEL(
 		model.Class{
 			Code:      arg.Code,
@@ -69,8 +64,6 @@ func (d *DB) CreateClass(ctx context.Context, arg CreateClassParams) (model.Clas
 			Semester:  arg.Semester,
 			Programme: arg.Programme,
 			Au:        arg.Au,
-			CreatedAt: now,
-			UpdatedAt: now,
 		},
 	).RETURNING(
 		Classes.AllColumns,

--- a/backend/internal/database/config/migrations/000001_initial.up.sql
+++ b/backend/internal/database/config/migrations/000001_initial.up.sql
@@ -10,8 +10,8 @@ CREATE TABLE users
     name       TEXT        NOT NULL,
     email      TEXT        NOT NULL,
     role       USER_ROLE   NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL,
-    updated_at TIMESTAMPTZ NOT NULL
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
 CREATE TABLE classes
@@ -22,8 +22,8 @@ CREATE TABLE classes
     semester   TEXT        NOT NULL,
     programme  TEXT        NOT NULL,
     au         SMALLINT    NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL,
-    updated_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     CONSTRAINT ux_code_year_semester
         UNIQUE (code, year, semester)
 );
@@ -34,8 +34,8 @@ CREATE TABLE class_groups
     class_id   BIGINT      NOT NULL,
     name       TEXT        NOT NULL,
     class_type CLASS_TYPE  NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL,
-    updated_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     CONSTRAINT ux_class_id_name_class_type
         UNIQUE (class_id, name, class_type),
     CONSTRAINT fk_class_id
@@ -50,8 +50,8 @@ CREATE TABLE class_group_sessions
     start_time     TIMESTAMPTZ NOT NULL,
     end_time       TIMESTAMPTZ NOT NULL,
     venue          TEXT        NOT NULL,
-    created_at     TIMESTAMPTZ NOT NULL,
-    updated_at     TIMESTAMPTZ NOT NULL,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     CONSTRAINT ux_class_group_id_start_time
         UNIQUE (class_group_id, start_time),
     CONSTRAINT fk_class_group_id
@@ -67,8 +67,8 @@ CREATE TABLE session_enrollments
     session_id BIGINT      NOT NULL,
     user_id    TEXT        NOT NULL,
     attended   BOOLEAN     NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL,
-    updated_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     CONSTRAINT ux_session_id_user_id
         UNIQUE (session_id, user_id),
     CONSTRAINT fk_session_id

--- a/backend/internal/database/session_enrollments.go
+++ b/backend/internal/database/session_enrollments.go
@@ -2,7 +2,6 @@ package database
 
 import (
 	"context"
-	"time"
 
 	"github.com/darylhjd/oams/backend/internal/database/gen/oams/public/model"
 	. "github.com/darylhjd/oams/backend/internal/database/gen/oams/public/table"
@@ -49,21 +48,15 @@ type CreateSessionEnrollmentParams struct {
 func (d *DB) CreateSessionEnrollment(ctx context.Context, arg CreateSessionEnrollmentParams) (model.SessionEnrollment, error) {
 	var res model.SessionEnrollment
 
-	now := time.Now()
-
 	stmt := SessionEnrollments.INSERT(
 		SessionEnrollments.SessionID,
 		SessionEnrollments.UserID,
 		SessionEnrollments.Attended,
-		SessionEnrollments.CreatedAt,
-		SessionEnrollments.UpdatedAt,
 	).MODEL(
 		model.SessionEnrollment{
 			SessionID: arg.SessionID,
 			UserID:    arg.UserID,
 			Attended:  arg.Attended,
-			CreatedAt: now,
-			UpdatedAt: now,
 		},
 	).RETURNING(
 		SessionEnrollments.AllColumns,

--- a/backend/internal/database/users.go
+++ b/backend/internal/database/users.go
@@ -49,18 +49,17 @@ type CreateUserParams struct {
 func (d *DB) CreateUser(ctx context.Context, arg CreateUserParams) (model.User, error) {
 	var res model.User
 
-	now := time.Now()
-
 	stmt := Users.INSERT(
-		Users.AllColumns,
+		Users.ID,
+		Users.Name,
+		Users.Email,
+		Users.Role,
 	).MODEL(
 		model.User{
-			ID:        arg.ID,
-			Name:      arg.Name,
-			Email:     arg.Email,
-			Role:      arg.Role,
-			CreatedAt: now,
-			UpdatedAt: now,
+			ID:    arg.ID,
+			Name:  arg.Name,
+			Email: arg.Email,
+			Role:  arg.Role,
 		},
 	).RETURNING(
 		Users.AllColumns,


### PR DESCRIPTION
## Issue

Defaults can be provided for the created_at and updated_at fields so they do not need to be explicitly set.

## Describe this PR

1. Add time defaults.

## Test Plan

```go test ./...```

## Rollback Plan
Revert the PR.