### PR TITLE
fix: do not update name during user registration

### DIFF
--- a/backend/internal/servers/apiserver/v1/ms_login_callback.go
+++ b/backend/internal/servers/apiserver/v1/ms_login_callback.go
@@ -41,12 +41,10 @@ func (v *APIServerV1) msLoginCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Upsert user into database.
-	_, err = v.db.UpsertUsers(r.Context(), []database.UpsertUserParams{
-		{
-			ID:    authResult.IDToken.Name,
-			Email: authResult.Account.PreferredUsername,
-		},
+	// Register user. If user has logged in before, then nothing is done.
+	_, err = v.db.RegisterUser(r.Context(), database.RegisterUserParams{
+		ID:    authResult.IDToken.Name,
+		Email: authResult.Account.PreferredUsername,
 	})
 	if err != nil {
 		v.logInternalServerError(r, err)

--- a/backend/internal/servers/apiserver/v1/ms_login_callback_test.go
+++ b/backend/internal/servers/apiserver/v1/ms_login_callback_test.go
@@ -9,7 +9,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/darylhjd/oams/backend/internal/database"
+	"github.com/darylhjd/oams/backend/internal/database/gen/oams/public/model"
 	"github.com/darylhjd/oams/backend/internal/tests"
+	"github.com/darylhjd/oams/backend/pkg/to"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 
@@ -20,17 +23,29 @@ func TestAPIServerV1_msLoginCallback(t *testing.T) {
 	t.Parallel()
 
 	tts := []struct {
-		name            string
-		withState       state
-		wantCode        int
-		wantBody        apiResponse
-		wantRedirectUrl string
+		name             string
+		withState        state
+		withExistingUser bool
+		wantCode         int
+		wantBody         apiResponse
+		wantRedirectUrl  string
 	}{
 		{
-			"expected state, accepted callback",
+			"expected state, accepted callback with new user",
 			state{
 				Version: namespace,
 			},
+			false,
+			http.StatusSeeOther,
+			nil,
+			Url,
+		},
+		{
+			"expected state, accepted callback with existing user",
+			state{
+				Version: namespace,
+			},
+			true,
 			http.StatusSeeOther,
 			nil,
 			Url,
@@ -41,6 +56,7 @@ func TestAPIServerV1_msLoginCallback(t *testing.T) {
 				Version:     namespace,
 				RedirectUrl: "/randomUrl",
 			},
+			false,
 			http.StatusSeeOther,
 			nil,
 			"/randomUrl",
@@ -50,6 +66,7 @@ func TestAPIServerV1_msLoginCallback(t *testing.T) {
 			state{
 				Version: "wrong-version",
 			},
+			false,
 			http.StatusTeapot,
 			newErrorResponse(http.StatusInternalServerError, "wrong api version handling"),
 			"",
@@ -62,10 +79,24 @@ func TestAPIServerV1_msLoginCallback(t *testing.T) {
 			t.Parallel()
 
 			a := assert.New(t)
+			ctx := context.Background()
 			id := uuid.NewString()
 
 			v1 := newTestAPIServerV1(t, id)
 			defer tests.TearDown(t, v1.db, id)
+
+			var (
+				expectedUser model.User
+				err          error
+			)
+			if tt.withExistingUser {
+				tests.StubAuthContextUser(t, ctx, v1.db)
+				// Set a name to the auth context user so we can check for no change.
+				expectedUser, err = v1.db.UpdateUser(ctx, tests.MockAuthenticatorIDTokenName, database.UpdateUserParams{
+					Name: to.Ptr("TEST ACCOUNT NAME LIM"),
+				})
+				a.Nil(err)
+			}
 
 			stateBytes, err := json.Marshal(tt.withState)
 			a.Nil(err)
@@ -90,6 +121,12 @@ func TestAPIServerV1_msLoginCallback(t *testing.T) {
 
 			// Check that user that logged in exists in the database.
 			tests.CheckUserExists(a, context.Background(), v1.db, tests.MockAuthenticatorIDTokenName)
+			if tt.withExistingUser {
+				// Check that if the user is an existing user, then user's information is unchanged in database.
+				checkUser, err := v1.db.GetUser(ctx, tests.MockAuthenticatorIDTokenName)
+				a.Nil(err)
+				a.Equal(expectedUser, checkUser)
+			}
 
 			// Check that session cookie exists.
 			for _, cookie := range rr.Result().Cookies() {

--- a/backend/internal/tests/authenticator_mock.go
+++ b/backend/internal/tests/authenticator_mock.go
@@ -13,8 +13,8 @@ import (
 const (
 	MockAuthenticatorAccessToken              = "mock-access-token"
 	MockAuthenticatorAccountHomeAccountID     = "mock-home-account-id"
-	MockAuthenticatorAccountPreferredUsername = "NTU0001@e.ntu.edu.sg"
 	MockAuthenticatorIDTokenName              = "TESTACC001"
+	MockAuthenticatorAccountPreferredUsername = "NTU0001@e.ntu.edu.sg"
 )
 
 // MockAzureAuthenticator allows us to mock the calls to Microsoft's Azure AD APIs.

--- a/backend/internal/tests/database_stub.go
+++ b/backend/internal/tests/database_stub.go
@@ -12,10 +12,10 @@ import (
 )
 
 // StubAuthContextUser inserts the mock auth context user into the database.
-func StubAuthContextUser(t *testing.T, ctx context.Context, db *database.DB) {
+func StubAuthContextUser(t *testing.T, ctx context.Context, db *database.DB) model.User {
 	t.Helper()
 
-	_, err := db.CreateUser(ctx, database.CreateUserParams{
+	user, err := db.CreateUser(ctx, database.CreateUserParams{
 		ID:    MockAuthenticatorIDTokenName,
 		Email: MockAuthenticatorAccountPreferredUsername,
 		Role:  model.UserRole_Student,
@@ -23,6 +23,8 @@ func StubAuthContextUser(t *testing.T, ctx context.Context, db *database.DB) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	return user
 }
 
 // StubUser inserts a mock user with the given ID into the database.


### PR DESCRIPTION
## Issue

Currently, the usage of upsert user in the ms login callback causes an issue where the name of the user is removed for existing users. This is because using the upsert user db action also sets the name if available, but this is not available during the login process.

So, we need to use a separate action that does not set the name.

## Describe this PR

1. Use register user as a separate database action that does not remove the name during subsequent logins.

## Test Plan

```go test ./...```

## Rollback Plan
Revert the PR.