### PR TITLE
refactor: remove need for isMobile arguments in flutter

### DIFF
--- a/frontend/lib/screens/about_screen.dart
+++ b/frontend/lib/screens/about_screen.dart
@@ -7,7 +7,7 @@ class AboutScreen extends StatelessWidget {
   static const double _mobilePadding = 10;
   static const double _desktopPadding = 20;
 
-  const AboutScreen({Key? key}) : super(key: key);
+  const AboutScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -20,7 +20,7 @@ class AboutScreen extends StatelessWidget {
     return ListView(
       padding: const EdgeInsets.all(_mobilePadding),
       children: const [
-        _PoweredByFlutter(true),
+        _PoweredByFlutter(),
       ],
     );
   }
@@ -29,7 +29,7 @@ class AboutScreen extends StatelessWidget {
     return ListView(
       padding: const EdgeInsets.all(_desktopPadding),
       children: const [
-        _PoweredByFlutter(false),
+        _PoweredByFlutter(),
       ],
     );
   }
@@ -40,13 +40,14 @@ class _PoweredByFlutter extends StatelessWidget {
   static const double _mobileSize = 100;
   static const double _desktopSize = 200;
   static const String _tagline = "Powered by:";
-  final bool _isMobile;
 
-  const _PoweredByFlutter(this._isMobile, {Key? key}) : super(key: key);
+  const _PoweredByFlutter();
 
   @override
   Widget build(BuildContext context) {
-    return _isMobile ? _mobile(context) : _desktop(context);
+    return ResponsiveBreakpoints.of(context).isMobile
+        ? _mobile(context)
+        : _desktop(context);
   }
 
   Widget _mobile(BuildContext context) {

--- a/frontend/lib/screens/home_screen_guest.dart
+++ b/frontend/lib/screens/home_screen_guest.dart
@@ -14,37 +14,21 @@ class HomeScreenGuest extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ScreenTemplate(
-      ResponsiveBreakpoints.of(context).isMobile
-          ? _mobile(context)
-          : _desktop(context),
-    );
-  }
-
-  Widget _mobile(BuildContext context) {
-    return ListView(
-      padding: const EdgeInsets.symmetric(vertical: _mobilePadding),
-      children: const [
-        _WelcomeBanner(true),
-        _FeaturesDivider(),
-        _Features(true),
-        Divider(),
-        _FinalActionCall(true),
-        Divider(),
-      ],
-    );
-  }
-
-  Widget _desktop(BuildContext context) {
-    return ListView(
-      padding: const EdgeInsets.symmetric(vertical: _desktopPadding),
-      children: const [
-        _WelcomeBanner(false),
-        _FeaturesDivider(),
-        _Features(false),
-        Divider(),
-        _FinalActionCall(false),
-        Divider(),
-      ],
+      ListView(
+        padding: EdgeInsets.symmetric(
+          vertical: ResponsiveBreakpoints.of(context).isMobile
+              ? _mobilePadding
+              : _desktopPadding,
+        ),
+        children: const [
+          _WelcomeBanner(),
+          _FeaturesDivider(),
+          _Features(),
+          Divider(),
+          _FinalActionCall(),
+          Divider(),
+        ],
+      ),
     );
   }
 }
@@ -68,13 +52,13 @@ class _WelcomeBanner extends StatelessWidget {
   static const double _desktopButtonHorizontalPadding = 20;
   static const double _desktopButtonFontSize = 24;
 
-  final bool _isMobile;
-
-  const _WelcomeBanner(this._isMobile);
+  const _WelcomeBanner();
 
   @override
   Widget build(BuildContext context) {
-    return _isMobile ? _mobile(context) : _desktop(context);
+    return ResponsiveBreakpoints.of(context).isMobile
+        ? _mobile(context)
+        : _desktop(context);
   }
 
   Widget _mobile(BuildContext context) {
@@ -183,29 +167,14 @@ class _FeaturesDivider extends StatelessWidget {
 
 // Contains the list of features of OAMS on the guest home screen.
 class _Features extends StatelessWidget {
-  final bool _isMobile;
-
-  const _Features(this._isMobile);
+  const _Features();
 
   @override
   Widget build(BuildContext context) {
-    return _isMobile ? _mobile(context) : _desktop();
-  }
-
-  Widget _mobile(BuildContext context) {
     return const Column(
       children: [
-        _CloudBasedFeature(true),
-        _DetailedSystemDashboard(true),
-      ],
-    );
-  }
-
-  Widget _desktop() {
-    return const Column(
-      children: [
-        _CloudBasedFeature(false),
-        _DetailedSystemDashboard(false),
+        _CloudBasedFeature(),
+        _DetailedSystemDashboard(),
       ],
     );
   }
@@ -222,13 +191,14 @@ class _FeatureCard extends StatelessWidget {
 
   final String _title;
   final String _body;
-  final bool _isMobile;
 
-  const _FeatureCard(this._title, this._body, this._isMobile);
+  const _FeatureCard(this._title, this._body);
 
   @override
   Widget build(BuildContext context) {
-    return _isMobile ? _mobile(context) : _desktop(context);
+    return ResponsiveBreakpoints.of(context).isMobile
+        ? _mobile(context)
+        : _desktop(context);
   }
 
   Widget _mobile(BuildContext context) {
@@ -287,13 +257,11 @@ class _CloudBasedFeature extends StatelessWidget {
   static const String _body =
       "Say goodbye to cumbersome paper-based attendance sheets. OAMS stores attendance data online so you can stay up-to-date wherever you are - instantly.";
 
-  final bool _isMobile;
-
-  const _CloudBasedFeature(this._isMobile);
+  const _CloudBasedFeature();
 
   @override
   Widget build(BuildContext context) {
-    return _FeatureCard(_title, _body, _isMobile);
+    return const _FeatureCard(_title, _body);
   }
 }
 
@@ -303,13 +271,11 @@ class _DetailedSystemDashboard extends StatelessWidget {
   static const String _body =
       "Get comprehensive access to attendance data. Our system dashboard provides you with detailed visualisations of your most important analytics - all at your fingertips.";
 
-  final bool _isMobile;
-
-  const _DetailedSystemDashboard(this._isMobile);
+  const _DetailedSystemDashboard();
 
   @override
   Widget build(BuildContext context) {
-    return _FeatureCard(_title, _body, _isMobile);
+    return const _FeatureCard(_title, _body);
   }
 }
 
@@ -331,13 +297,13 @@ class _FinalActionCall extends StatelessWidget {
   static const double _desktopButtonVerticalPadding = 20;
   static const double _desktopButtonHorizontalPadding = 10;
 
-  final bool _isMobile;
-
-  const _FinalActionCall(this._isMobile);
+  const _FinalActionCall();
 
   @override
   Widget build(BuildContext context) {
-    return _isMobile ? _mobile(context) : _desktop(context);
+    return ResponsiveBreakpoints.of(context).isMobile
+        ? _mobile(context)
+        : _desktop(context);
   }
 
   Widget _mobile(BuildContext context) {

--- a/frontend/lib/screens/home_screen_logged.dart
+++ b/frontend/lib/screens/home_screen_logged.dart
@@ -28,7 +28,7 @@ class HomeScreenLoggedIn extends ConsumerWidget {
       children: [
         _UpcomingSessionsCalendar(),
         const SizedBox(height: _mobilePadding),
-        const _SelectedDaySessionsPreviewer(true),
+        const _SelectedDaySessionsPreviewer(),
         const SizedBox(height: _mobilePadding),
         const Placeholder(),
       ],
@@ -45,7 +45,7 @@ class HomeScreenLoggedIn extends ConsumerWidget {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               Flexible(child: _UpcomingSessionsCalendar()),
-              const _SelectedDaySessionsPreviewer(false),
+              const _SelectedDaySessionsPreviewer(),
             ],
           ),
         ),
@@ -177,13 +177,13 @@ class _SelectedDaySessionsPreviewer extends ConsumerWidget {
   static const double _desktopPadding = 10;
   static const double _desktopWidth = 400;
 
-  final bool _isMobile;
-
-  const _SelectedDaySessionsPreviewer(this._isMobile);
+  const _SelectedDaySessionsPreviewer();
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return _isMobile ? _mobile(context, ref) : _desktop(context, ref);
+    return ResponsiveBreakpoints.of(context).isMobile
+        ? _mobile(context, ref)
+        : _desktop(context, ref);
   }
 
   Widget _mobile(BuildContext context, WidgetRef ref) {
@@ -250,7 +250,7 @@ class _SelectedDaySessionsPreviewer extends ConsumerWidget {
   List<_EventPreview> _getEventPreviews(WidgetRef ref) {
     return ref
         .watch(_selectedDayEventsProvider)
-        .map((e) => _EventPreview(e, _isMobile))
+        .map((e) => _EventPreview(e))
         .toList();
   }
 }
@@ -297,9 +297,8 @@ class _EventPreview extends StatelessWidget {
   static const double _desktopPadding = 20;
 
   final UpcomingClassGroupSession _session;
-  final bool _isMobile;
 
-  const _EventPreview(this._session, this._isMobile);
+  const _EventPreview(this._session);
 
   @override
   Widget build(BuildContext context) {
@@ -308,7 +307,11 @@ class _EventPreview extends StatelessWidget {
     return Card(
       color: _colorMap[_session.classType],
       child: Container(
-        padding: EdgeInsets.all(_isMobile ? _mobilePadding : _desktopPadding),
+        padding: EdgeInsets.all(
+          ResponsiveBreakpoints.of(context).isMobile
+              ? _mobilePadding
+              : _desktopPadding,
+        ),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [

--- a/frontend/lib/screens/user_screen.dart
+++ b/frontend/lib/screens/user_screen.dart
@@ -1,15 +1,46 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:frontend/api/client.dart';
+import 'package:frontend/api/models.dart';
 import 'package:frontend/screens/screen_template.dart';
+import 'package:frontend/widgets/dialogs.dart';
 
-class UserScreen extends StatelessWidget {
+final _userProvider = FutureProvider.autoDispose
+    .family<GetUserResponse, String>((ref, userId) async {
+  return await APIClient.getUser(userId);
+});
+
+// Shows information about a user.
+class UserScreen extends ConsumerWidget {
   final String _userId;
 
   const UserScreen(this._userId, {super.key});
 
   @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ScreenTemplate(ref.watch(_userProvider(_userId)).when(
+          data: (data) => _screen(context, data),
+          error: (error, stackTrace) => const InvalidSession(),
+          loading: () => const Center(child: CircularProgressIndicator()),
+        ));
+  }
+
+  Widget _screen(BuildContext context, GetUserResponse data) {
+    return ListView(children: [
+      _UserHeader(data),
+    ]);
+  }
+}
+
+class _UserHeader extends StatelessWidget {
+  final GetUserResponse _data;
+
+  const _UserHeader(this._data);
+
+  @override
   Widget build(BuildContext context) {
-    return ScreenTemplate(
-      Text(_userId),
-    );
+    return Column(children: [
+      Text(_data.user.id),
+    ]);
   }
 }

--- a/frontend/lib/widgets/nav_bar.dart
+++ b/frontend/lib/widgets/nav_bar.dart
@@ -15,7 +15,7 @@ class NavBar extends StatelessWidget {
   static final List<BoxShadow>? _boxShadow = kElevationToShadow[8];
   static const double _borderRadius = 10;
 
-  const NavBar({Key? key}) : super(key: key);
+  const NavBar();
 
   @override
   Widget build(BuildContext context) {
@@ -43,7 +43,7 @@ class NavBar extends StatelessWidget {
       mainAxisSize: MainAxisSize.max,
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
-        _Options(true),
+        _Options(),
         _Logo(),
       ],
     );
@@ -55,7 +55,7 @@ class NavBar extends StatelessWidget {
       children: [
         _Logo(),
         Flexible(
-          child: _Options(false),
+          child: _Options(),
         ),
       ],
     );
@@ -70,7 +70,7 @@ class _Logo extends StatelessWidget {
 
   static const String _logoPath = "assets/logo.png";
 
-  const _Logo({Key? key}) : super(key: key);
+  const _Logo();
 
   @override
   Widget build(BuildContext context) {
@@ -87,14 +87,12 @@ class _Logo extends StatelessWidget {
 
 // Stores all the navigation bar items except the logo.
 class _Options extends ConsumerWidget {
-  final bool _isMobile;
-
-  const _Options(this._isMobile, {Key? key}) : super(key: key);
+  const _Options();
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final isLoggedIn = ref.read(sessionProvider);
-    return _isMobile
+    return ResponsiveBreakpoints.of(context).isMobile
         ? _mobile(context, ref, isLoggedIn)
         : _desktop(context, ref, isLoggedIn);
   }
@@ -103,7 +101,7 @@ class _Options extends ConsumerWidget {
     var items = <PopupMenuItem<Widget>>[
       const PopupMenuItem(
         padding: EdgeInsets.zero,
-        child: _AboutButton(true),
+        child: _AboutButton(),
       ),
     ];
 
@@ -112,7 +110,7 @@ class _Options extends ConsumerWidget {
       items.addAll([
         const PopupMenuItem(
           padding: EdgeInsets.zero,
-          child: _ProfileButton(true),
+          child: _ProfileButton(),
         ),
         const PopupMenuItem(
           padding: EdgeInsets.zero,
@@ -122,7 +120,7 @@ class _Options extends ConsumerWidget {
     } else {
       items.add(const PopupMenuItem(
         padding: EdgeInsets.zero,
-        child: _LoginButton(true),
+        child: _LoginButton(),
       ));
     }
 
@@ -140,8 +138,8 @@ class _Options extends ConsumerWidget {
             ? _loggedDesktopItems(context, ref)
             : const SizedBox.shrink(),
         const Spacer(),
-        const _AboutButton(false),
-        isLoggedIn ? const _ProfileButton(false) : const _LoginButton(false),
+        const _AboutButton(),
+        isLoggedIn ? const _ProfileButton() : const _LoginButton(),
       ],
     );
   }
@@ -154,7 +152,7 @@ class _Options extends ConsumerWidget {
       if (userRole == UserRole.admin)
         const PopupMenuItem(
           padding: EdgeInsets.zero,
-          child: _AdminPanelButton(true),
+          child: _AdminPanelButton(),
         ),
     ];
   }
@@ -165,7 +163,7 @@ class _Options extends ConsumerWidget {
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
-        if (userRole == UserRole.admin) const _AdminPanelButton(false),
+        if (userRole == UserRole.admin) const _AdminPanelButton(),
       ],
     );
   }
@@ -176,13 +174,14 @@ class _Options extends ConsumerWidget {
 // widget does the checking.
 class _AdminPanelButton extends StatelessWidget {
   static const _text = _NavBarText("Admin Panel");
-  final bool _isMobile;
 
-  const _AdminPanelButton(this._isMobile);
+  const _AdminPanelButton();
 
   @override
   Widget build(BuildContext context) {
-    return _isMobile ? _mobile(context) : _desktop(context);
+    return ResponsiveBreakpoints.of(context).isMobile
+        ? _mobile(context)
+        : _desktop(context);
   }
 
   Widget _mobile(BuildContext context) {
@@ -203,13 +202,14 @@ class _AdminPanelButton extends StatelessWidget {
 // Shows the About button on the navigation bar.
 class _AboutButton extends StatelessWidget {
   final Widget _text = const _NavBarText("About");
-  final bool _isMobile;
 
-  const _AboutButton(this._isMobile, {Key? key}) : super(key: key);
+  const _AboutButton();
 
   @override
   Widget build(BuildContext context) {
-    return _isMobile ? _mobile(context) : _desktop(context);
+    return ResponsiveBreakpoints.of(context).isMobile
+        ? _mobile(context)
+        : _desktop(context);
   }
 
   Widget _mobile(BuildContext context) {
@@ -230,13 +230,14 @@ class _AboutButton extends StatelessWidget {
 // Shows the Profile button on the navigation bar.
 class _ProfileButton extends StatelessWidget {
   final Widget _text = const _NavBarText("Profile");
-  final bool _isMobile;
 
-  const _ProfileButton(this._isMobile, {Key? key}) : super(key: key);
+  const _ProfileButton();
 
   @override
   Widget build(BuildContext context) {
-    return _isMobile ? _mobile(context) : _desktop(context);
+    return ResponsiveBreakpoints.of(context).isMobile
+        ? _mobile(context)
+        : _desktop(context);
   }
 
   Widget _mobile(BuildContext context) {
@@ -266,13 +267,14 @@ class _ProfileButton extends StatelessWidget {
 // Shows the Login button on the navigation bar.
 class _LoginButton extends StatelessWidget {
   final Widget _text = const _NavBarText("Login");
-  final bool _isMobile;
 
-  const _LoginButton(this._isMobile, {Key? key}) : super(key: key);
+  const _LoginButton();
 
   @override
   Widget build(BuildContext context) {
-    return _isMobile ? _mobile(context) : _desktop(context);
+    return ResponsiveBreakpoints.of(context).isMobile
+        ? _mobile(context)
+        : _desktop(context);
   }
 
   Widget _mobile(BuildContext context) {
@@ -294,7 +296,7 @@ class _LoginButton extends StatelessWidget {
 class _LogoutButton extends ConsumerWidget {
   final Widget _text = const _NavBarText("Logout", color: Colors.red);
 
-  const _LogoutButton({Key? key}) : super(key: key);
+  const _LogoutButton();
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -331,9 +333,9 @@ class _NavBarText extends StatelessWidget {
   final String _text;
   final Color? _color;
 
-  const _NavBarText(this._text, {Key? key, Color? color})
+  const _NavBarText(this._text, {Color? color})
       : _color = color,
-        super(key: key);
+        super();
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
## Issue

Since the child widgets have direct access to the build context, we can just check there rather than passing the argument down, which makes the implementation messier than required.

## Describe this PR

1. Remove need for _isMobile arguments.
2. Change a little the implementation for the user screen.

## Test Plan

## Rollback Plan
Revert the PR.