### PR TITLE
fix: allow repeated batch puts

### DIFF
--- a/backend/internal/servers/apiserver/v1/batch.go
+++ b/backend/internal/servers/apiserver/v1/batch.go
@@ -158,7 +158,6 @@ func (v *APIServerV1) batchPut(r *http.Request) apiResponse {
 
 // processBatchPutRequest and return a batchPutResponse and error if encountered.
 // This implementation aims to reduce database actions by sacrificing memory usage.
-// TODO: This endpoint returns an internal server error with rows not found message if the upsert does nothing.
 func (v *APIServerV1) processBatchPutRequest(r *http.Request, req batchPutRequest) (batchPutResponse, error) {
 	resp := batchPutResponse{
 		response: newSuccessResponse(),
@@ -207,7 +206,7 @@ func (v *APIServerV1) processBatchPutRequest(r *http.Request, req batchPutReques
 		classesParams = append(classesParams, class.Class)
 	}
 
-	upsertClasses, err := txDb.UpsertClasses(r.Context(), classesParams)
+	upsertClasses, err := txDb.BatchUpsertClasses(r.Context(), classesParams)
 	if err != nil {
 		return resp, err
 	}
@@ -223,7 +222,7 @@ func (v *APIServerV1) processBatchPutRequest(r *http.Request, req batchPutReques
 		}
 	}
 
-	upsertClassGroups, err := txDb.UpsertClassGroups(r.Context(), classGroupsParams)
+	upsertClassGroups, err := txDb.BatchUpsertClassGroups(r.Context(), classGroupsParams)
 	if err != nil {
 		return resp, err
 	}
@@ -243,7 +242,7 @@ func (v *APIServerV1) processBatchPutRequest(r *http.Request, req batchPutReques
 		}
 	}
 
-	upsertClassGroupSessions, err := txDb.UpsertClassGroupSessions(r.Context(), classGroupSessionsParams)
+	upsertClassGroupSessions, err := txDb.BatchUpsertClassGroupSessions(r.Context(), classGroupSessionsParams)
 	if err != nil {
 		return resp, err
 	}
@@ -257,11 +256,11 @@ func (v *APIServerV1) processBatchPutRequest(r *http.Request, req batchPutReques
 		}
 	}
 
-	if _, err = txDb.UpsertUsers(r.Context(), usersParams); err != nil {
+	if _, err = txDb.BatchUpsertUsers(r.Context(), usersParams); err != nil {
 		return resp, err
 	}
 
-	if _, err = txDb.UpsertSessionEnrollments(r.Context(), enrollmentsParams); err != nil {
+	if _, err = txDb.BatchUpsertSessionEnrollments(r.Context(), enrollmentsParams); err != nil {
 		return resp, err
 	}
 

--- a/backend/internal/servers/apiserver/v1/v1.go
+++ b/backend/internal/servers/apiserver/v1/v1.go
@@ -70,10 +70,9 @@ func (v *APIServerV1) registerHandlers() {
 	v.mux.HandleFunc(msLoginCallbackUrl, middleware.AllowMethods(v.msLoginCallback, http.MethodPost))
 	v.mux.HandleFunc(logoutUrl, middleware.WithAuthContext(v.logout, v.azure))
 
-	v.mux.HandleFunc(batchUrl, middleware.WithAuthContext(
+	v.mux.HandleFunc(batchUrl,
 		middleware.AllowMethods(v.batch, http.MethodPost, http.MethodPut),
-		v.azure,
-	))
+	)
 
 	v.mux.HandleFunc(usersUrl, middleware.WithAuthContext(
 		middleware.AllowMethods(v.users, http.MethodGet, http.MethodPost),

--- a/frontend/lib/screens/user_screen.dart
+++ b/frontend/lib/screens/user_screen.dart
@@ -18,11 +18,15 @@ class UserScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return ScreenTemplate(ref.watch(_userProvider(_userId)).when(
-          data: (data) => _screen(context, data),
-          error: (error, stackTrace) => const InvalidSession(),
-          loading: () => const Center(child: CircularProgressIndicator()),
-        ));
+    return ScreenTemplate(
+      ref.watch(_userProvider(_userId)).when(
+            data: (data) => _screen(context, data),
+            error: (error, stackTrace) => const InvalidSession(),
+            loading: () => const Center(
+              child: CircularProgressIndicator(),
+            ),
+          ),
+    );
   }
 
   Widget _screen(BuildContext context, GetUserResponse data) {

--- a/frontend/lib/widgets/nav_bar.dart
+++ b/frontend/lib/widgets/nav_bar.dart
@@ -15,7 +15,7 @@ class NavBar extends StatelessWidget {
   static final List<BoxShadow>? _boxShadow = kElevationToShadow[8];
   static const double _borderRadius = 10;
 
-  const NavBar();
+  const NavBar({super.key});
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
## Issue

Currently, the batch endpoint errors out if we repeat the same request the second time. However, we want it to be able to return correct values regardless of if there are updates or not.

## Describe this PR

1. Change implementation of the batch sqls to return values regardless.

## Test Plan

```go test ./...```

## Rollback Plan
Revert the PR.