### PR TITLE
fix: do not set email on upsert user

### DIFF
--- a/backend/internal/database/users.go
+++ b/backend/internal/database/users.go
@@ -135,9 +135,8 @@ func (d *DB) DeleteUser(ctx context.Context, id string) (model.User, error) {
 }
 
 type UpsertUserParams struct {
-	ID    string `json:"id"`
-	Name  string `json:"name"`
-	Email string `json:"email"`
+	ID   string `json:"id"`
+	Name string `json:"name"`
 }
 
 // BatchUpsertUsers inserts a batch of users into the database. If the user already exists, then update the name and
@@ -154,9 +153,8 @@ func (d *DB) BatchUpsertUsers(ctx context.Context, args []UpsertUserParams) ([]m
 			if _, ok := dupFinder[param]; !ok {
 				dupFinder[param] = struct{}{}
 				inserts = append(inserts, model.User{
-					ID:    param.ID,
-					Name:  param.Name,
-					Email: param.Email,
+					ID:   param.ID,
+					Name: param.Name,
 				})
 			}
 		}
@@ -173,7 +171,6 @@ func (d *DB) BatchUpsertUsers(ctx context.Context, args []UpsertUserParams) ([]m
 	).DO_UPDATE(
 		SET(
 			Users.Name.SET(Users.EXCLUDED.Name),
-			Users.Email.SET(Users.EXCLUDED.Email),
 		),
 	).RETURNING(
 		Users.AllColumns,

--- a/backend/internal/servers/apiserver/common/batch_file_parser_test.go
+++ b/backend/internal/servers/apiserver/common/batch_file_parser_test.go
@@ -61,8 +61,8 @@ func TestParseBatchFile(t *testing.T) {
 							},
 						},
 						[]database.UpsertUserParams{
-							{"CHUX6789", "CHUA XIN YI", ""},
-							{"YAPW9087", "YAP WEN LI", ""},
+							{"CHUX6789", "CHUA XIN YI"},
+							{"YAPW9087", "YAP WEN LI"},
 						},
 					},
 					{
@@ -83,8 +83,8 @@ func TestParseBatchFile(t *testing.T) {
 							},
 						},
 						[]database.UpsertUserParams{
-							{"BENST129", "BENJAMIN SANTOS", ""},
-							{"YAPW9088", "YAP WEI LING", ""},
+							{"BENST129", "BENJAMIN SANTOS"},
+							{"YAPW9088", "YAP WEI LING"},
 						},
 					},
 					{
@@ -115,8 +115,8 @@ func TestParseBatchFile(t *testing.T) {
 							},
 						},
 						[]database.UpsertUserParams{
-							{"PATELAR14", "ARJUN PATEL", ""},
-							{"YAPX9087", "YAP XIN TING", ""},
+							{"PATELAR14", "ARJUN PATEL"},
+							{"YAPX9087", "YAP XIN TING"},
 						},
 					},
 				},

--- a/backend/internal/servers/apiserver/v1/batch_test.go
+++ b/backend/internal/servers/apiserver/v1/batch_test.go
@@ -188,8 +188,8 @@ func TestAPIServerV1_batchPut(t *testing.T) {
 										},
 									},
 									[]database.UpsertUserParams{
-										{"CHUL6789", "CHUA LI TING", ""},
-										{"YAPW9087", "YAP WEN LI", ""},
+										{"CHUL6789", "CHUA LI TING"},
+										{"YAPW9087", "YAP WEN LI"},
 									},
 								},
 								{
@@ -205,8 +205,8 @@ func TestAPIServerV1_batchPut(t *testing.T) {
 										},
 									},
 									[]database.UpsertUserParams{
-										{"BENST129", "BENJAMIN SANTOS", ""},
-										{"YAPW9088", "YAP WEI LING", ""},
+										{"BENST129", "BENJAMIN SANTOS"},
+										{"YAPW9088", "YAP WEI LING"},
 									},
 								},
 								{
@@ -222,8 +222,8 @@ func TestAPIServerV1_batchPut(t *testing.T) {
 										},
 									},
 									[]database.UpsertUserParams{
-										{"PATELAR14", "ARJUN PATEL", ""},
-										{"YAPX9087", "YAP XIN TING", ""},
+										{"PATELAR14", "ARJUN PATEL"},
+										{"YAPX9087", "YAP XIN TING"},
 									},
 								},
 							},


### PR DESCRIPTION
## Issue

When an existing user is updated through batch processing, their email is removed. We want to prevent this by making email a non-updated field in the batch upsert.

## Describe this PR

1. Remove email from batch upsert.

## Test Plan

```go test ./...```

## Rollback Plan
Revert the PR.