### PR TITLE
feat: simplify getauthcontext middleware

### DIFF
--- a/backend/internal/database/users.go
+++ b/backend/internal/database/users.go
@@ -17,7 +17,7 @@ func (d *DB) ListUsers(ctx context.Context, params listParams) ([]model.User, er
 	stmt := SELECT(
 		Users.AllColumns,
 	).FROM(
-		Users.Table,
+		Users,
 	).ORDER_BY(
 		Users.ID.ASC(),
 	)

--- a/backend/internal/middleware/middleware_test.go
+++ b/backend/internal/middleware/middleware_test.go
@@ -40,8 +40,16 @@ func TestGetAuthContext(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/", nil)
 			req = req.WithContext(context.WithValue(req.Context(), AuthContextKey, tt.contextValue))
 
-			_, err := GetAuthContext(req.Context())
-			a.Equal(tt.wantErr, err)
+			switch {
+			case tt.wantErr != nil:
+				a.PanicsWithError(tt.wantErr.Error(), func() {
+					GetAuthContext(req.Context())
+				})
+			default:
+				a.NotPanics(func() {
+					GetAuthContext(req.Context())
+				})
+			}
 		})
 	}
 }

--- a/backend/internal/servers/apiserver/v1/logout_test.go
+++ b/backend/internal/servers/apiserver/v1/logout_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/darylhjd/oams/backend/internal/tests"
 	"github.com/google/uuid"
@@ -19,62 +18,29 @@ import (
 func TestAPIServerV1_logOut(t *testing.T) {
 	t.Parallel()
 
-	tts := []struct {
-		name            string
-		withAuthContext any
-		wantResponse    apiResponse
-	}{
-		{
-			"request with account in context",
-			tests.NewMockAuthContext(),
-			logoutResponse{newSuccessResponse()},
-		},
-		{
-			"request with wrong account type in context",
-			time.Time{},
-			newErrorResponse(http.StatusInternalServerError, middleware.ErrUnexpectedAuthContextType.Error()),
-		},
-		{
-			"request with no account in context",
-			nil,
-			newErrorResponse(http.StatusInternalServerError, middleware.ErrNoAuthContext.Error()),
-		},
+	a := assert.New(t)
+	ctx := context.Background()
+	id := uuid.NewString()
+
+	v1 := newTestAPIServerV1(t, id)
+	defer tests.TearDown(t, v1.db, id)
+
+	tests.StubAuthContextUser(t, ctx, v1.db)
+
+	req := httptest.NewRequest(http.MethodGet, logoutUrl, nil)
+	req = req.WithContext(context.WithValue(req.Context(), middleware.AuthContextKey, tests.NewMockAuthContext()))
+	rr := httptest.NewRecorder()
+	v1.logout(rr, req)
+
+	expectedBytes, err := json.Marshal(logoutResponse{newSuccessResponse()})
+	a.Nil(err)
+	a.Equal(string(expectedBytes), rr.Body.String())
+
+	// Check for session deletion cookie.
+	for _, cookie := range rr.Result().Cookies() {
+		if cookie.Name == oauth2.SessionCookieIdent {
+			return
+		}
 	}
-
-	for _, tt := range tts {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			a := assert.New(t)
-			ctx := context.Background()
-			id := uuid.NewString()
-
-			v1 := newTestAPIServerV1(t, id)
-			defer tests.TearDown(t, v1.db, id)
-
-			tests.StubAuthContextUser(t, ctx, v1.db)
-
-			req := httptest.NewRequest(http.MethodGet, logoutUrl, nil)
-			req = req.WithContext(context.WithValue(req.Context(), middleware.AuthContextKey, tt.withAuthContext))
-			rr := httptest.NewRecorder()
-			v1.logout(rr, req)
-
-			expectedBytes, err := json.Marshal(tt.wantResponse)
-			a.Nil(err)
-			a.Equal(string(expectedBytes), rr.Body.String())
-
-			if tt.wantResponse.Code() != http.StatusOK {
-				return
-			}
-
-			// Check for session deletion cookie.
-			for _, cookie := range rr.Result().Cookies() {
-				if cookie.Name == oauth2.SessionCookieIdent {
-					return
-				}
-			}
-			a.FailNow("could not detect expected session deletion cookie")
-		})
-	}
+	a.FailNow("could not detect expected session deletion cookie")
 }

--- a/backend/internal/servers/apiserver/v1/user_test.go
+++ b/backend/internal/servers/apiserver/v1/user_test.go
@@ -118,15 +118,6 @@ func TestAPIServerV1_userMe(t *testing.T) {
 			"",
 		},
 		{
-			"request with invalid auth context",
-			time.Time{},
-			true,
-			false,
-			userMeResponse{},
-			http.StatusInternalServerError,
-			"unexpected auth context type",
-		},
-		{
 			"request with valid auth context but non-existent user in database",
 			tests.NewMockAuthContext(),
 			false,


### PR DESCRIPTION
## Issue

Currently, the function returns an error. However, we can make it panic which will help reduce the amount of boilerplate we write within our endpoints. The http server will automatically recover from the panic.

## Describe this PR

1. Simplify the getauthcontext middleware.
2. Remove some redundant tests.
3. Fix other tests.

## Test Plan

```go test ./...```

## Rollback Plan
Revert the PR.