### PR TITLE
feat: move authcontext to its own package

### DIFF
--- a/backend/internal/middleware/middleware_test.go
+++ b/backend/internal/middleware/middleware_test.go
@@ -1,58 +1,12 @@
 package middleware
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
-
-func TestGetAuthContext(t *testing.T) {
-	tests := []struct {
-		name         string
-		contextValue any
-		wantErr      error
-	}{
-		{
-			"with proper context value",
-			AuthContext{},
-			nil,
-		},
-		{
-			"bad context value",
-			time.Time{},
-			ErrUnexpectedAuthContextType,
-		},
-		{
-			"no context value",
-			nil,
-			ErrNoAuthContext,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			a := assert.New(t)
-
-			req := httptest.NewRequest(http.MethodGet, "/", nil)
-			req = req.WithContext(context.WithValue(req.Context(), AuthContextKey, tt.contextValue))
-
-			switch {
-			case tt.wantErr != nil:
-				a.PanicsWithError(tt.wantErr.Error(), func() {
-					GetAuthContext(req.Context())
-				})
-			default:
-				a.NotPanics(func() {
-					GetAuthContext(req.Context())
-				})
-			}
-		})
-	}
-}
 
 func TestAllowMethods(t *testing.T) {
 	tests := []struct {

--- a/backend/internal/middleware/values/auth_context.go
+++ b/backend/internal/middleware/values/auth_context.go
@@ -1,0 +1,40 @@
+package values
+
+import (
+	"context"
+	"errors"
+
+	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/confidential"
+	"github.com/darylhjd/oams/backend/internal/oauth2"
+)
+
+const (
+	AuthContextKey = "auth_context"
+)
+
+var (
+	ErrNoAuthContext             = errors.New("no auth context found")
+	ErrUnexpectedAuthContextType = errors.New("unexpected auth context type")
+)
+
+// AuthContext stores useful information regarding an authentication.
+type AuthContext struct {
+	Claims     *oauth2.AzureClaims
+	AuthResult confidential.AuthResult
+}
+
+// GetAuthContext is a helper function to get the authentication context from a request context. If the auth context is
+// not present, or it is of a wrong type, then GetAuthContext panics.
+func GetAuthContext(ctx context.Context) AuthContext {
+	val := ctx.Value(AuthContextKey)
+	if val == nil {
+		panic(ErrNoAuthContext)
+	}
+
+	authContext, ok := val.(AuthContext)
+	if !ok {
+		panic(ErrUnexpectedAuthContextType)
+	}
+
+	return authContext
+}

--- a/backend/internal/middleware/values/auth_context_test.go
+++ b/backend/internal/middleware/values/auth_context_test.go
@@ -1,0 +1,55 @@
+package values
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetAuthContext(t *testing.T) {
+	tests := []struct {
+		name         string
+		contextValue any
+		wantErr      error
+	}{
+		{
+			"with proper context value",
+			AuthContext{},
+			nil,
+		},
+		{
+			"bad context value",
+			time.Time{},
+			ErrUnexpectedAuthContextType,
+		},
+		{
+			"no context value",
+			nil,
+			ErrNoAuthContext,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := assert.New(t)
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req = req.WithContext(context.WithValue(req.Context(), AuthContextKey, tt.contextValue))
+
+			switch {
+			case tt.wantErr != nil:
+				a.PanicsWithError(tt.wantErr.Error(), func() {
+					GetAuthContext(req.Context())
+				})
+			default:
+				a.NotPanics(func() {
+					GetAuthContext(req.Context())
+				})
+			}
+		})
+	}
+}

--- a/backend/internal/servers/apiserver/v1/logout.go
+++ b/backend/internal/servers/apiserver/v1/logout.go
@@ -3,7 +3,7 @@ package v1
 import (
 	"net/http"
 
-	"github.com/darylhjd/oams/backend/internal/middleware"
+	"github.com/darylhjd/oams/backend/internal/middleware/values"
 	"github.com/darylhjd/oams/backend/internal/oauth2"
 )
 
@@ -14,7 +14,7 @@ type logoutResponse struct {
 func (v *APIServerV1) logout(w http.ResponseWriter, r *http.Request) {
 	var resp apiResponse = logoutResponse{newSuccessResponse()}
 
-	authContext := middleware.GetAuthContext(r.Context())
+	authContext := values.GetAuthContext(r.Context())
 	if err := v.azure.RemoveAccount(r.Context(), authContext.AuthResult.Account); err != nil {
 		v.logInternalServerError(r, err)
 		resp = newErrorResponse(http.StatusInternalServerError, "error clearing account cache")

--- a/backend/internal/servers/apiserver/v1/logout_test.go
+++ b/backend/internal/servers/apiserver/v1/logout_test.go
@@ -7,11 +7,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/darylhjd/oams/backend/internal/middleware/values"
 	"github.com/darylhjd/oams/backend/internal/tests"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/darylhjd/oams/backend/internal/middleware"
 	"github.com/darylhjd/oams/backend/internal/oauth2"
 )
 
@@ -28,7 +28,7 @@ func TestAPIServerV1_logOut(t *testing.T) {
 	tests.StubAuthContextUser(t, ctx, v1.db)
 
 	req := httptest.NewRequest(http.MethodGet, logoutUrl, nil)
-	req = req.WithContext(context.WithValue(req.Context(), middleware.AuthContextKey, tests.NewMockAuthContext()))
+	req = req.WithContext(context.WithValue(req.Context(), values.AuthContextKey, tests.NewMockAuthContext()))
 	rr := httptest.NewRecorder()
 	v1.logout(rr, req)
 

--- a/backend/internal/servers/apiserver/v1/user.go
+++ b/backend/internal/servers/apiserver/v1/user.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/darylhjd/oams/backend/internal/database"
 	"github.com/darylhjd/oams/backend/internal/database/gen/oams/public/model"
-	"github.com/darylhjd/oams/backend/internal/middleware"
+	"github.com/darylhjd/oams/backend/internal/middleware/values"
 	"github.com/go-jet/jet/v2/qrm"
 )
 
@@ -49,7 +49,7 @@ func (v *APIServerV1) userMe(r *http.Request) apiResponse {
 		UpcomingClassGroupSessions: []database.UpcomingClassGroupSession{},
 	}
 
-	authContext := middleware.GetAuthContext(r.Context())
+	authContext := values.GetAuthContext(r.Context())
 
 	sessionUser, err := v.db.GetUser(r.Context(), authContext.AuthResult.IDToken.Name)
 	if err != nil {

--- a/backend/internal/servers/apiserver/v1/user_test.go
+++ b/backend/internal/servers/apiserver/v1/user_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/darylhjd/oams/backend/internal/database"
 	"github.com/darylhjd/oams/backend/internal/database/gen/oams/public/model"
-	"github.com/darylhjd/oams/backend/internal/middleware"
+	"github.com/darylhjd/oams/backend/internal/middleware/values"
 	"github.com/darylhjd/oams/backend/internal/tests"
 	"github.com/darylhjd/oams/backend/pkg/to"
 	"github.com/google/uuid"
@@ -161,7 +161,7 @@ func TestAPIServerV1_userMe(t *testing.T) {
 			}
 
 			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", userUrl, sessionUserId), nil)
-			req = req.WithContext(context.WithValue(req.Context(), middleware.AuthContextKey, tt.withAuthContext))
+			req = req.WithContext(context.WithValue(req.Context(), values.AuthContextKey, tt.withAuthContext))
 			resp := v1.userMe(req)
 			a.Equal(tt.wantStatusCode, resp.Code())
 

--- a/backend/internal/tests/middleware_mock.go
+++ b/backend/internal/tests/middleware_mock.go
@@ -1,13 +1,13 @@
 package tests
 
 import (
-	"github.com/darylhjd/oams/backend/internal/middleware"
+	"github.com/darylhjd/oams/backend/internal/middleware/values"
 	"github.com/darylhjd/oams/backend/internal/oauth2"
 )
 
 // NewMockAuthContext creates a middleware.AuthContext with mock information.
-func NewMockAuthContext() middleware.AuthContext {
-	return middleware.AuthContext{
+func NewMockAuthContext() values.AuthContext {
+	return values.AuthContext{
 		Claims:     &oauth2.AzureClaims{},
 		AuthResult: NewMockAzureAuthenticator().MockAuthResult(),
 	}


### PR DESCRIPTION
## Issue

Since it is not really a middleware but rather an extension of it.

## Describe this PR

1. Move to own package.

## Test Plan

```go test ./...```

## Rollback Plan
Revert the PR.