### PR TITLE
feat: add user to authcontext

### DIFF
--- a/backend/internal/middleware/values/auth_context.go
+++ b/backend/internal/middleware/values/auth_context.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/confidential"
+	"github.com/darylhjd/oams/backend/internal/database/gen/oams/public/model"
 	"github.com/darylhjd/oams/backend/internal/oauth2"
 )
 
@@ -21,6 +22,7 @@ var (
 type AuthContext struct {
 	Claims     *oauth2.AzureClaims
 	AuthResult confidential.AuthResult
+	User       model.User
 }
 
 // GetAuthContext is a helper function to get the authentication context from a request context. If the auth context is

--- a/backend/internal/servers/apiserver/v1/v1.go
+++ b/backend/internal/servers/apiserver/v1/v1.go
@@ -69,71 +69,71 @@ func (v *APIServerV1) registerHandlers() {
 
 	v.mux.HandleFunc(loginUrl, v.login)
 	v.mux.HandleFunc(msLoginCallbackUrl, middleware.AllowMethods(v.msLoginCallback, http.MethodPost))
-	v.mux.HandleFunc(logoutUrl, middleware.MustAuth(v.logout, v.azure))
+	v.mux.HandleFunc(logoutUrl, middleware.MustAuth(v.logout, v.azure, v.db))
 
 	v.mux.HandleFunc(batchUrl, middleware.MustAuth(
-		middleware.AllowMethodsWithPermissions(v.batch, v.db,
+		middleware.AllowMethodsWithPermissions(v.batch,
 			map[string][]permissions.Permission{
 				http.MethodPost: {permissions.PermissionBatchPost},
 				http.MethodPut:  {permissions.PermissionBatchPut},
 			},
 		),
-		v.azure,
+		v.azure, v.db,
 	))
 
 	v.mux.HandleFunc(usersUrl, middleware.MustAuth(
-		middleware.AllowMethodsWithPermissions(v.users, v.db,
+		middleware.AllowMethodsWithPermissions(v.users,
 			map[string][]permissions.Permission{
 				http.MethodGet:  {permissions.PermissionUserRead},
 				http.MethodPost: {permissions.PermissionUserCreate},
 			},
 		),
-		v.azure,
+		v.azure, v.db,
 	))
 
 	v.mux.HandleFunc(userUrl, middleware.MustAuth(
 		middleware.AllowMethods(v.user, http.MethodGet, http.MethodPatch, http.MethodDelete),
-		v.azure,
+		v.azure, v.db,
 	))
 
 	v.mux.HandleFunc(classesUrl, middleware.MustAuth(
 		middleware.AllowMethods(v.classes, http.MethodGet, http.MethodPost),
-		v.azure,
+		v.azure, v.db,
 	))
 
 	v.mux.HandleFunc(classUrl, middleware.MustAuth(
 		middleware.AllowMethods(v.class, http.MethodGet, http.MethodPatch, http.MethodDelete),
-		v.azure,
+		v.azure, v.db,
 	))
 
 	v.mux.HandleFunc(classGroupsUrl, middleware.MustAuth(
 		middleware.AllowMethods(v.classGroups, http.MethodGet, http.MethodPost),
-		v.azure,
+		v.azure, v.db,
 	))
 
 	v.mux.HandleFunc(classGroupUrl, middleware.MustAuth(
 		middleware.AllowMethods(v.classGroup, http.MethodGet, http.MethodPatch, http.MethodDelete),
-		v.azure,
+		v.azure, v.db,
 	))
 
 	v.mux.HandleFunc(classGroupSessionsUrl, middleware.MustAuth(
 		middleware.AllowMethods(v.classGroupSessions, http.MethodGet, http.MethodPost),
-		v.azure,
+		v.azure, v.db,
 	))
 
 	v.mux.HandleFunc(classGroupSessionUrl, middleware.MustAuth(
 		middleware.AllowMethods(v.classGroupSession, http.MethodGet, http.MethodPatch, http.MethodDelete),
-		v.azure,
+		v.azure, v.db,
 	))
 
 	v.mux.HandleFunc(sessionEnrollmentsUrl, middleware.MustAuth(
 		middleware.AllowMethods(v.sessionEnrollments, http.MethodGet, http.MethodPost),
-		v.azure,
+		v.azure, v.db,
 	))
 
 	v.mux.HandleFunc(sessionEnrollmentUrl, middleware.MustAuth(
 		middleware.AllowMethods(v.sessionEnrollment, http.MethodGet, http.MethodPatch, http.MethodDelete),
-		v.azure,
+		v.azure, v.db,
 	))
 }
 


### PR DESCRIPTION
## Issue

Currently, the auth context does not contain information on the user from the database. We can add it since it might prove useful for further authorization/authentication.

## Describe this PR

1. Add user to authcontext.

## Test Plan

```go test ./...```

## Rollback Plan
Revert the PR.