### PR TITLE
fix: add timezone data to go programme

### DIFF
--- a/backend/internal/servers/apiserver/v1/v1.go
+++ b/backend/internal/servers/apiserver/v1/v1.go
@@ -71,9 +71,15 @@ func (v *APIServerV1) registerHandlers() {
 	v.mux.HandleFunc(msLoginCallbackUrl, middleware.AllowMethods(v.msLoginCallback, http.MethodPost))
 	v.mux.HandleFunc(logoutUrl, middleware.MustAuth(v.logout, v.azure, v.db))
 
-	v.mux.HandleFunc(batchUrl,
-		v.batch,
-	)
+	v.mux.HandleFunc(batchUrl, middleware.MustAuth(
+		middleware.AllowMethodsWithPermissions(v.batch,
+			map[string][]permissions.Permission{
+				http.MethodPost: {permissions.PermissionBatchPost},
+				http.MethodPut:  {permissions.PermissionBatchPut},
+			},
+		),
+		v.azure, v.db,
+	))
 
 	v.mux.HandleFunc(usersUrl, middleware.MustAuth(
 		middleware.AllowMethodsWithPermissions(v.users,


### PR DESCRIPTION
## Issue

Batch POST endpoint is failing because it makes use of `location` but loading fails because the timezone data is not embedded in the programme.

## Describe this PR

1. The fix is simple, which is just to import go's own timezone data. The impact of this is an increase in the size of the programme by about 450KB which is negligible.

## Test Plan

```go test ./...```

Also tested on branch deployment.

## Rollback Plan
Revert the PR.