### PR TITLE
feat: add information on about page

### DIFF
--- a/frontend/src/app/about/page.tsx
+++ b/frontend/src/app/about/page.tsx
@@ -1,11 +1,17 @@
 "use client";
 
-import { Center } from "@mantine/core";
+import { Container, Text } from "@mantine/core";
 
 export default function AboutPage() {
   return (
-    <Center>
-      <p>This is the about page.</p>
-    </Center>
+    <Container>
+      <Text align="center">
+        This application is created as part of the Final Year Paper requirement
+        for the Bachelor of Engineering in Computer Science in Nanyang
+        Technological University.
+      </Text>
+      <br />
+      <Text align="center">Copyright &#169; Har Jing Daryl, 2023</Text>
+    </Container>
   );
 }


### PR DESCRIPTION
## Issue
Currently, the about page is a filler page with no real content. We should fill it with some sensible information at least.
## Describe this PR

1. Fill with some information about the project and copyright.

## Test Plan

![image](https://github.com/darylhjd/oams/assets/53652695/62e793ce-e604-43f4-9ef4-549e853299d7)

## Rollback Plan
Revert the PR.