### PR TITLE
fix: do not go to 404 on logout at adminpanel page

### DIFF
--- a/frontend/src/components/header.tsx
+++ b/frontend/src/components/header.tsx
@@ -291,15 +291,16 @@ const ProfileButton: React.FC<MobileProp> = ({ mobile = false }) => {
 };
 
 const LogoutButton = () => {
+  const router = useRouter();
   const session = sessionStore();
 
   return (
     <Menu.Item
       icon={<IconLogout color="red" />}
       onClick={async () => {
-        session.invalidate();
         await APIClient.logout();
-        location.href = Routes.home;
+        session.invalidate();
+        router.push(Routes.index);
       }}
     >
       <Text c="red">Logout</Text>

--- a/frontend/src/routes/checks.ts
+++ b/frontend/src/routes/checks.ts
@@ -10,7 +10,7 @@ export function redirectIfLoggedIn(): boolean {
   const session = sessionStore();
 
   if (session.data != null) {
-    location.replace(Routes.home);
+    location.replace(Routes.index);
     return true;
   }
 
@@ -43,7 +43,7 @@ export function redirectIfNotUserRole(userRole: UserRole): boolean {
   }
 
   if (session.data!.session_user.role != userRole) {
-    location.replace(Routes.home);
+    location.replace(Routes.index);
     return true;
   }
 

--- a/frontend/src/routes/routes.ts
+++ b/frontend/src/routes/routes.ts
@@ -1,5 +1,5 @@
 export const Routes = {
-  home: "/",
+  index: "/",
   login: "/login",
   about: "/about",
   profile: "/profile",


### PR DESCRIPTION
## Issue

There is an issue where clicking the logout button from the admin panel or batch processing page will redirect the user to the 404 page.

## Describe this PR

1. Fix.

## Test Plan

Test on dev environment.

## Rollback Plan
Revert the PR.