### PR TITLE
fix: keep last known max page for async data table

### DIFF
--- a/frontend/src/components/entity_tables.tsx
+++ b/frontend/src/components/entity_tables.tsx
@@ -112,7 +112,7 @@ export abstract class AsyncDataSource {
     if (knownLength < offset + limit) {
       this.totalRecords = knownLength;
     } else {
-      this.totalRecords = offset + 2 * limit; // Allows possible fetch of next page.
+      this.totalRecords = Math.max(this.totalRecords, offset + 2 * limit); // Allows possible fetch of next page.
     }
   }
 


### PR DESCRIPTION
## Issue

Currently, the async data table removes last known pages when going back to earlier pages. We want to allow the user to go back to the last known page.

## Describe this PR

1. Fix data source to return last total records it knows.

## Test Plan

Test on local admin panel.

## Rollback Plan
Revert the PR.