### PR TITLE
fix(backend/apiserver): remove ordering for entity list gets

### DIFF
--- a/backend/internal/database/class_group_sessions.go
+++ b/backend/internal/database/class_group_sessions.go
@@ -16,9 +16,6 @@ func (d *DB) ListClassGroupSessions(ctx context.Context, params listParams) ([]m
 		ClassGroupSessions.AllColumns,
 	).FROM(
 		ClassGroupSessions,
-	).ORDER_BY(
-		ClassGroupSessions.ClassGroupID,
-		ClassGroupSessions.StartTime,
 	)
 
 	stmt = setSorts(stmt, params)

--- a/backend/internal/database/class_groups.go
+++ b/backend/internal/database/class_groups.go
@@ -16,9 +16,6 @@ func (d *DB) ListClassGroups(ctx context.Context, params listParams) ([]model.Cl
 		ClassGroups.AllColumns,
 	).FROM(
 		ClassGroups,
-	).ORDER_BY(
-		ClassGroups.ClassID,
-		ClassGroups.Name,
 	)
 
 	stmt = setSorts(stmt, params)

--- a/backend/internal/database/classes.go
+++ b/backend/internal/database/classes.go
@@ -15,10 +15,6 @@ func (d *DB) ListClasses(ctx context.Context, params listParams) ([]model.Class,
 		Classes.AllColumns,
 	).FROM(
 		Classes,
-	).ORDER_BY(
-		Classes.Code,
-		Classes.Year,
-		Classes.Semester,
 	)
 
 	stmt = setSorts(stmt, params)

--- a/backend/internal/database/session_enrollments.go
+++ b/backend/internal/database/session_enrollments.go
@@ -16,9 +16,6 @@ func (d *DB) ListSessionEnrollments(ctx context.Context, params listParams) ([]m
 		SessionEnrollments.AllColumns,
 	).FROM(
 		SessionEnrollments,
-	).ORDER_BY(
-		SessionEnrollments.SessionID,
-		SessionEnrollments.UserID,
 	)
 
 	stmt = setSorts(stmt, params)


### PR DESCRIPTION
## Issue

Currently, the apiserver does some custom ordering when getting a list of entities. Except for the users (where no bigserial id is used), we should follow the normal database ordering unless specified by the user.

## Describe this PR

1. Remove custom hardcoded ordering.

## Test Plan

```go test ./...```

## Rollback Plan
Revert the PR.