### PR TITLE
feat(backend/apiserver): add class managers skeleton

### DIFF
--- a/backend/internal/permissions/permissions.go
+++ b/backend/internal/permissions/permissions.go
@@ -18,6 +18,11 @@ const (
 	ClassUpdate
 	ClassDelete
 
+	ClassManagerCreate
+	ClassManagerRead
+	ClassManagerUpdate
+	ClassManagerDelete
+
 	ClassGroupCreate
 	ClassGroupRead
 	ClassGroupUpdate
@@ -78,6 +83,11 @@ var systemAdminRolePermissions = permissionMap{
 	ClassRead:   {},
 	ClassUpdate: {},
 	ClassDelete: {},
+
+	ClassManagerCreate: {},
+	ClassManagerRead:   {},
+	ClassManagerUpdate: {},
+	ClassManagerDelete: {},
 
 	ClassGroupCreate: {},
 	ClassGroupRead:   {},

--- a/backend/internal/servers/apiserver/v1/class_managers.go
+++ b/backend/internal/servers/apiserver/v1/class_managers.go
@@ -1,0 +1,20 @@
+package v1
+
+import (
+	"net/http"
+)
+
+func (v *APIServerV1) classManagers(w http.ResponseWriter, r *http.Request) {
+	var resp apiResponse
+
+	switch r.Method {
+	case http.MethodGet:
+		resp = newErrorResponse(http.StatusNotImplemented, "")
+	case http.MethodPost:
+		resp = newErrorResponse(http.StatusNotImplemented, "")
+	default:
+		resp = newErrorResponse(http.StatusMethodNotAllowed, "")
+	}
+
+	v.writeResponse(w, r, resp)
+}

--- a/backend/internal/servers/apiserver/v1/class_managers_test.go
+++ b/backend/internal/servers/apiserver/v1/class_managers_test.go
@@ -1,0 +1,56 @@
+package v1
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/darylhjd/oams/backend/internal/tests"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAPIServerV1_classManagers(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name           string
+		withMethod     string
+		wantStatusCode int
+	}{
+		{
+			"with GET method",
+			http.MethodGet,
+			http.StatusNotImplemented,
+		},
+		{
+			"with POST method",
+			http.MethodPost,
+			http.StatusNotImplemented,
+		},
+		{
+			"with DELETE method",
+			http.MethodDelete,
+			http.StatusMethodNotAllowed,
+		},
+	}
+
+	for _, tt := range tts {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := assert.New(t)
+			id := uuid.NewString()
+
+			v1 := newTestAPIServerV1(t, id)
+			defer tests.TearDown(t, v1.db, id)
+
+			req := httptest.NewRequest(tt.withMethod, classManagersUrl, nil)
+			rr := httptest.NewRecorder()
+			v1.classManagers(rr, req)
+
+			a.Equal(tt.wantStatusCode, rr.Code)
+		})
+	}
+}

--- a/backend/internal/servers/apiserver/v1/v1.go
+++ b/backend/internal/servers/apiserver/v1/v1.go
@@ -33,6 +33,7 @@ const (
 	userUrl               = "/users/"
 	classesUrl            = "/classes"
 	classUrl              = "/classes/"
+	classManagersUrl      = "/class-managers"
 	classGroupsUrl        = "/class-groups"
 	classGroupUrl         = "/class-groups/"
 	classGroupSessionsUrl = "/class-group-sessions"
@@ -116,6 +117,15 @@ func (v *APIServerV1) registerHandlers() {
 				http.MethodGet:    {permissions.ClassRead},
 				http.MethodPatch:  {permissions.ClassUpdate},
 				http.MethodDelete: {permissions.ClassDelete},
+			}),
+		v.azure, v.db,
+	))
+
+	v.mux.HandleFunc(classManagersUrl, middleware.MustAuth(
+		middleware.AllowMethodsWithPermissions(v.classManagers,
+			map[string][]permissions.P{
+				http.MethodGet:  {permissions.ClassManagerRead},
+				http.MethodPost: {permissions.ClassManagerCreate},
 			}),
 		v.azure, v.db,
 	))


### PR DESCRIPTION
## Issue

We want to support storing manager information.

## Describe this PR

1. Add required permissions.
2. Add skeleton to support future class managers endpoints.

## Test Plan

```go test ./...```

## Rollback Plan
Revert the PR.