### PR TITLE
feat(backend/database): add database actions for class managers

### DIFF
--- a/backend/internal/database/class_managers.go
+++ b/backend/internal/database/class_managers.go
@@ -1,0 +1,53 @@
+package database
+
+import (
+	"context"
+
+	"github.com/darylhjd/oams/backend/internal/database/gen/oams/public/model"
+	. "github.com/darylhjd/oams/backend/internal/database/gen/oams/public/table"
+	. "github.com/go-jet/jet/v2/postgres"
+)
+
+func (d *DB) ListClassManagers(ctx context.Context, params listParams) ([]model.ClassManager, error) {
+	var res []model.ClassManager
+
+	stmt := SELECT(
+		ClassManagers.AllColumns,
+	).FROM(
+		ClassManagers,
+	)
+
+	stmt = setSorts(stmt, params)
+	stmt = setLimit(stmt, params)
+	stmt = setOffset(stmt, params)
+
+	err := stmt.QueryContext(ctx, d.qe, &res)
+	return res, err
+}
+
+type CreateClassManagerParams struct {
+	UserID       string             `json:"user_id"`
+	ClassID      int64              `json:"class_id"`
+	ManagingRole model.ManagingRole `json:"managing_role"`
+}
+
+func (d *DB) CreateClassManager(ctx context.Context, arg CreateClassManagerParams) (model.ClassManager, error) {
+	var res model.ClassManager
+
+	stmt := ClassManagers.INSERT(
+		ClassManagers.UserID,
+		ClassManagers.ClassID,
+		ClassManagers.ManagingRole,
+	).MODEL(
+		model.ClassManager{
+			UserID:       arg.UserID,
+			ClassID:      arg.ClassID,
+			ManagingRole: arg.ManagingRole,
+		},
+	).RETURNING(
+		ClassManagers.AllColumns,
+	)
+
+	err := stmt.QueryContext(ctx, d.qe, &res)
+	return res, err
+}

--- a/backend/internal/tests/database_stub.go
+++ b/backend/internal/tests/database_stub.go
@@ -61,6 +61,26 @@ func StubClass(t *testing.T, ctx context.Context, db *database.DB, code string, 
 	return class
 }
 
+// StubClassManager inserts a mock user and class into the database, and then makes the user
+// a manager of the mocked class.
+func StubClassManager(t *testing.T, ctx context.Context, db *database.DB, role model.ManagingRole) model.ClassManager {
+	t.Helper()
+
+	user := StubUser(t, ctx, db, uuid.NewString(), model.UserRole_User)
+	class := StubClass(t, ctx, db, uuid.NewString(), rand.Int31(), uuid.NewString())
+
+	manager, err := db.CreateClassManager(ctx, database.CreateClassManagerParams{
+		UserID:       user.ID,
+		ClassID:      class.ID,
+		ManagingRole: role,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return manager
+}
+
 // StubClassGroup inserts a mock class and a corresponding class group into the database.
 func StubClassGroup(t *testing.T, ctx context.Context, db *database.DB, name string, classType model.ClassType) model.ClassGroup {
 	t.Helper()


### PR DESCRIPTION
## Issue

We want to support some database actions for the class managers table.

## Describe this PR

1. Add list action
2. Add create action

## Test Plan

```go test ./...```

## Rollback Plan
Revert the PR.