### PR TITLE
fix(frontend/adminpanel): show attended field for session enrollments table

### DIFF
--- a/frontend/src/components/entity_tables.tsx
+++ b/frontend/src/components/entity_tables.tsx
@@ -1,3 +1,4 @@
+import { SessionEnrollment } from "@/api/models";
 import { DataTable, DataTableColumn } from "mantine-datatable";
 import { useEffect, useState } from "react";
 
@@ -65,7 +66,10 @@ export const SessionEnrollmentsDataTableColumns = [
   { accessor: "id", title: "ID" },
   { accessor: "session_id", title: "Session ID" },
   { accessor: "user_id", title: "User ID" },
-  { accessor: "attended" },
+  {
+    accessor: "attended",
+    render: (record: SessionEnrollment) => record.attended.toString(),
+  },
   ...CreatedAtUpdatedAtDataTableColumns,
 ];
 


### PR DESCRIPTION
## Issue

Currently, the session enrollments table does not render the `attended` field properly.

## Describe this PR
1. Fix the rendering.

## Test Plan

Before (notice attended field is empty):
![image](https://github.com/darylhjd/oams/assets/53652695/55084c5f-2fa2-4f9f-b4de-21cae168b9de)

After:
![image](https://github.com/darylhjd/oams/assets/53652695/48c8d414-bf84-4854-9d15-d8c40b8a7912)

## Rollback Plan
Test on local admin panel.