### PR TITLE
feat(frontend): use generics for data tables

### DIFF
--- a/frontend/src/app/admin-panel/data_source.tsx
+++ b/frontend/src/app/admin-panel/data_source.tsx
@@ -1,8 +1,16 @@
 import { APIClient } from "@/api/client";
+import {
+  Class,
+  ClassGroup,
+  ClassGroupSession,
+  ClassManager,
+  SessionEnrollment,
+  User,
+} from "@/api/models";
 import { AsyncDataSource } from "@/components/entity_tables";
 
-export class UsersDataSource extends AsyncDataSource {
-  async getRows(offset: number, limit: number): Promise<any[]> {
+export class UsersDataSource extends AsyncDataSource<User> {
+  async getRows(offset: number, limit: number): Promise<User[]> {
     const response = await APIClient.usersGet(offset, limit);
     if (response == null) {
       return [];
@@ -13,8 +21,8 @@ export class UsersDataSource extends AsyncDataSource {
   }
 }
 
-export class ClassesDataSource extends AsyncDataSource {
-  async getRows(offset: number, limit: number): Promise<any[]> {
+export class ClassesDataSource extends AsyncDataSource<Class> {
+  async getRows(offset: number, limit: number): Promise<Class[]> {
     const response = await APIClient.classesGet(offset, limit);
     if (response == null) {
       return [];
@@ -25,8 +33,8 @@ export class ClassesDataSource extends AsyncDataSource {
   }
 }
 
-export class ClassManagersDataSource extends AsyncDataSource {
-  async getRows(offset: number, limit: number): Promise<any[]> {
+export class ClassManagersDataSource extends AsyncDataSource<ClassManager> {
+  async getRows(offset: number, limit: number): Promise<ClassManager[]> {
     const response = await APIClient.classManagersGet(offset, limit);
     if (response == null) {
       return [];
@@ -41,8 +49,8 @@ export class ClassManagersDataSource extends AsyncDataSource {
   }
 }
 
-export class ClassGroupsDataSource extends AsyncDataSource {
-  async getRows(offset: number, limit: number): Promise<any[]> {
+export class ClassGroupsDataSource extends AsyncDataSource<ClassGroup> {
+  async getRows(offset: number, limit: number): Promise<ClassGroup[]> {
     const response = await APIClient.classGroupsGet(offset, limit);
     if (response == null) {
       return [];
@@ -57,8 +65,8 @@ export class ClassGroupsDataSource extends AsyncDataSource {
   }
 }
 
-export class ClassGroupSessionsDataSource extends AsyncDataSource {
-  async getRows(offset: number, limit: number): Promise<any[]> {
+export class ClassGroupSessionsDataSource extends AsyncDataSource<ClassGroupSession> {
+  async getRows(offset: number, limit: number): Promise<ClassGroupSession[]> {
     const response = await APIClient.classGroupSessionsGet(offset, limit);
     if (response == null) {
       return [];
@@ -73,8 +81,8 @@ export class ClassGroupSessionsDataSource extends AsyncDataSource {
   }
 }
 
-export class SessionEnrollmentsDataSource extends AsyncDataSource {
-  async getRows(offset: number, limit: number): Promise<any[]> {
+export class SessionEnrollmentsDataSource extends AsyncDataSource<SessionEnrollment> {
+  async getRows(offset: number, limit: number): Promise<SessionEnrollment[]> {
     const response = await APIClient.sessionEnrollmentsGet(offset, limit);
     if (response == null) {
       return [];

--- a/frontend/src/components/entity_tables.tsx
+++ b/frontend/src/components/entity_tables.tsx
@@ -1,6 +1,6 @@
 import { SessionEnrollment } from "@/api/models";
 import { DataTable, DataTableColumn } from "mantine-datatable";
-import { useEffect, useState } from "react";
+import { useEffect, useState, MouseEvent } from "react";
 
 const CreatedAtUpdatedAtDataTableColumns = [
   { accessor: "created_at", title: "Created At" },
@@ -73,12 +73,12 @@ export const SessionEnrollmentsDataTableColumns = [
   ...CreatedAtUpdatedAtDataTableColumns,
 ];
 
-export function BatchDataTable({
+export function BatchDataTable<T>({
   columns,
   records,
 }: {
-  columns: DataTableColumn<any>[];
-  records: any[];
+  columns: DataTableColumn<T>[];
+  records: T[];
 }) {
   const PAGE_SIZE = 50;
 
@@ -108,7 +108,7 @@ export function BatchDataTable({
   );
 }
 
-export abstract class AsyncDataSource {
+export abstract class AsyncDataSource<T> {
   constructor(
     public totalRecords: number = 0,
     public isApproximateRowCount: boolean = true,
@@ -128,20 +128,22 @@ export abstract class AsyncDataSource {
     }
   }
 
-  abstract getRows(offset: number, limit: number): Promise<any[]>;
+  abstract getRows(offset: number, limit: number): Promise<T[]>;
 }
 
-export function AsyncDataTable({
+export function AsyncDataTable<T>({
   columns,
   dataSource,
+  onRowClick,
 }: {
-  columns: DataTableColumn<any>[];
-  dataSource: AsyncDataSource;
+  columns: DataTableColumn<T>[];
+  dataSource: AsyncDataSource<T>;
+  onRowClick?: (record: T, recordIndex: number, event: MouseEvent) => void;
 }) {
   const PAGE_SIZE = 100;
 
   const [page, setPage] = useState(1);
-  const [pageRecords, setPageRecords] = useState<any[]>([]);
+  const [pageRecords, setPageRecords] = useState<T[]>([]);
   const [totalRecords, setTotalRecords] = useState(0);
   const [fetching, setFetching] = useState(false);
 
@@ -169,6 +171,7 @@ export function AsyncDataTable({
       page={page}
       onPageChange={(p) => setPage(p)}
       fetching={fetching}
+      onRowClick={onRowClick}
     />
   );
 }


### PR DESCRIPTION
## Issue

Currently, the data table implementations use `any` type for the columns and records. While this is working okay, we can introduce better type safety through the use of generics.

## Describe this PR

1. Use generics for record types for data tables.
2. Add `onRowClick` option to prepare for row click implementation.

## Test Plan

Compilation OK.

## Rollback Plan
Revert the PR.