### PR TITLE
feat(frontend): allow row click on admin panel users table

### DIFF
--- a/frontend/src/app/admin-panel/tables.tsx
+++ b/frontend/src/app/admin-panel/tables.tsx
@@ -1,5 +1,5 @@
 import {
-  MRT_ColumnDef,
+  MRT_TableOptions,
   MRT_PaginationState,
   MantineReactTable,
 } from "mantine-react-table";
@@ -21,14 +21,25 @@ import {
   SessionEnrollmentsDataTableColumns,
   UserDataTableColumns,
 } from "@/components/entity_columns";
+import { useRouter } from "next/navigation";
+import { Routes } from "@/routing/routes";
 
 const DEFAULT_PAGE_SIZE = 10;
+const ROW_PROPS = {
+  style: { cursor: "pointer" },
+};
 
 export function UsersTable() {
+  const router = useRouter();
+
   return (
     <AsyncDataTable
       columns={UserDataTableColumns}
       dataSource={new UsersDataSource()}
+      mantineTableBodyRowProps={({ row }) => ({
+        onClick: (_) => router.push(Routes.adminPanelUsers + row.original.id),
+        ...ROW_PROPS,
+      })}
     />
   );
 }
@@ -79,12 +90,11 @@ export function SessionEnrollmentsTable() {
 }
 
 function AsyncDataTable<T extends Record<string, any>>({
-  columns,
   dataSource,
+  ...props
 }: {
-  columns: MRT_ColumnDef<T>[];
   dataSource: AsyncDataSource<T>;
-}) {
+} & Omit<MRT_TableOptions<T>, "data">) {
   const [data, setData] = useState<T[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -107,7 +117,7 @@ function AsyncDataTable<T extends Record<string, any>>({
 
   return (
     <MantineReactTable
-      columns={columns}
+      {...props}
       data={data}
       manualPagination={true}
       rowCount={rowCount}

--- a/frontend/src/routing/routes.ts
+++ b/frontend/src/routing/routes.ts
@@ -3,5 +3,6 @@ export const Routes = {
   about: "/about",
   profile: "/profile",
   adminPanel: "/admin-panel",
+  adminPanelUsers: "/admin-panel/users/",
   batchProcessing: "/batch-processing",
 };


### PR DESCRIPTION
## Issue

Currently, the rows in the admin panel table are non clickable. We can add the ability to click to get more information and actions for the user.

## Describe this PR

1. Add click action on user table row.

## Test Plan

Test on local admin panel.

## Rollback Plan
Revert the PR.