### PR TITLE
fix(frontend): admin panel table loading screen overlaps header

### DIFF
--- a/frontend/src/components/header.tsx
+++ b/frontend/src/components/header.tsx
@@ -219,7 +219,12 @@ function SystemAdminMenu() {
   return (
     <>
       <Box visibleFrom="md">
-        <Menu width={200}>
+        <Menu
+          width={200}
+          classNames={{
+            dropdown: styles.systemAdminMenuDropdown,
+          }}
+        >
           <MenuTarget>
             <Button
               color="orange"

--- a/frontend/src/styles/Header.module.css
+++ b/frontend/src/styles/Header.module.css
@@ -1,7 +1,7 @@
 .header {
   position: sticky;
   top: 0;
-  z-index: 99;
+  z-index: 401;
   background-color: var(--mantine-color-default);
   border-bottom: rem(1px) solid var(--mantine-color-default-border);
   padding: rem(10px) rem(10px);
@@ -25,4 +25,8 @@
     width: 8rem;
     height: 90%;
   }
+}
+
+.systemAdminMenuDropdown {
+  z-index: 402 !important;
 }


### PR DESCRIPTION
## Issue

The loading element of the admin panel table overlaps the header.

## Describe this PR

1. Update z-index of components so that the loading component falls behind the header.

## Test Plan

Test on local admin panel.

## Rollback Plan
Revert the PR.