### PR TITLE
fix(frontend): wrong accessor key for class manager user id column

### DIFF
--- a/frontend/src/components/entity_columns.ts
+++ b/frontend/src/components/entity_columns.ts
@@ -44,7 +44,7 @@ export const ClassDataTableColumns = <MRT_ColumnDef<Class>[]>[
 
 export const ClassManagerDataTableColumns = <MRT_ColumnDef<ClassManager>[]>[
   { accessorKey: "id", header: "ID" },
-  { accessorKe: "user_id", header: "User ID" },
+  { accessorKey: "user_id", header: "User ID" },
   { accessorKey: "class_id", header: "Class ID" },
   { accessorKey: "managing_role", header: "Managing Role" },
   ...CreatedAtUpdatedAtDataTableColumns,


### PR DESCRIPTION
## Issue

The user id field accessor has a typo which prevents the table from showing the data correctly.

## Describe this PR
1. Fix the typo.

## Test Plan
```go test ./...```
## Rollback Plan
Revert the PR.