### PR TITLE
fix(backend): cors issue with PUT request with authorization header

### DIFF
--- a/backend/internal/servers/apiserver/server.go
+++ b/backend/internal/servers/apiserver/server.go
@@ -62,7 +62,7 @@ func (s *APIServer) Start() error {
 	c := cors.New(cors.Options{
 		AllowedOrigins:   []string{env.GetWebServer()},
 		AllowCredentials: true,
-		AllowedHeaders:   []string{"Authorization, Content-Type"},
+		AllowedHeaders:   []string{"Authorization", "Content-Type"},
 		AllowedMethods:   []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete},
 	})
 


### PR DESCRIPTION
## Issue

CORS blocks PUT requests with non-trivial content-type header when another non-trivial header (Authorization) is set.

## Describe this PR

1. Allow Content-Type header for CORS.

## Test Plan

```go test ./...```

Test on staging deployment.

## Rollback Plan
Revert the PR