### PR TITLE
feat: add supabase for local configuration

### DIFF
--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -15,9 +15,6 @@ services:
     ports:
       - "3001:3001"
     network_mode: bridge
-    depends_on:
-      local-db:
-        condition: service_healthy
 
   webserver:
     image: oams/webserver
@@ -34,12 +31,12 @@ services:
       apiserver:
         condition: service_started
 
-  local-db:
-    image: postgres:latest
-    container_name: local-db
+  test-db:
+    image: postgres:15
+    container_name: test-db
     environment:
-      POSTGRES_USER: oams
-      POSTGRES_PASSWORD: oams-local
+      POSTGRES_USER: oams-tester
+      POSTGRES_PASSWORD: oams-testing
     ports:
       - "3002:5432"
     network_mode: bridge

--- a/backend/supabase/.gitignore
+++ b/backend/supabase/.gitignore
@@ -1,0 +1,3 @@
+# Supabase
+.branches
+.temp

--- a/backend/supabase/README.md
+++ b/backend/supabase/README.md
@@ -1,0 +1,5 @@
+# Supabase
+
+This folder supports local development using Supabase.
+
+To get started, set up the supabase CLI, and then run `supabase start` in the project root folder.

--- a/backend/supabase/config.toml
+++ b/backend/supabase/config.toml
@@ -1,0 +1,80 @@
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "oams-local"
+
+[api]
+enabled = true
+port = 54321
+schemas = ["public", "storage", "graphql_public"]
+extra_search_path = ["public", "extensions"]
+max_rows = 1000
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 15
+
+[db.pooler]
+enabled = false
+
+[realtime]
+enabled = false
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://localhost"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+enabled = false
+
+[storage]
+enabled = false
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://localhost:54321/auth/v1/callback"
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = []
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+
+[auth.email]
+enable_signup = false
+
+[auth.sms]
+enable_signup = false
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+
+[auth.external.azure]
+enabled = true
+client_id = "env(SUPABASE_AUTH_EXTERNAL_AZURE_CLIENT_ID)"
+secret = "env(SUPABASE_AUTH_EXTERNAL_AZURE_SECRET)"
+url = "https://login.microsoftonline.com/9b2e3eb5-8a72-4dec-a5a3-4fa5fa3b7396"
+redirect_uri = "http://localhost:54321/auth/v1/callback"
+
+[analytics]
+enabled = true
+port = 54327
+vector_port = 54328
+backend = "postgres"


### PR DESCRIPTION
## Issue

Since our stack depends on Supabase, we should use it to support local development as well.

## Describe this PR

1. Add local supabase configuration. To use, do `supabase start`.
2. The local-db will now be delegated to just testing.

## Test Plan
```go test ./...```

## Rollback Plan
Revert the PR.