### PR TITLE
feat(backend/frontend): implement class group manager menu

### DIFF
--- a/backend/internal/database/class_group_managers.go
+++ b/backend/internal/database/class_group_managers.go
@@ -136,3 +136,20 @@ func (d *DB) BatchUpsertClassGroupManagers(ctx context.Context, args []UpsertCla
 	// TODO: Implement SQL.
 	return nil, nil
 }
+
+func (d *DB) GetManagedClassGroupsByUserID(ctx context.Context, userId string) ([]model.ClassGroupManager, error) {
+	var res []model.ClassGroupManager
+
+	stmt := SELECT(
+		ClassGroupManagers.AllColumns,
+	).FROM(
+		ClassGroupManagers,
+	).WHERE(
+		ClassGroupManagers.UserID.EQ(String(userId)).AND(
+			classGroupManagerRLS(ctx),
+		),
+	)
+
+	err := stmt.QueryContext(ctx, d.qe, &res)
+	return res, err
+}

--- a/backend/internal/database/users.go
+++ b/backend/internal/database/users.go
@@ -3,7 +3,6 @@ package database
 import (
 	"context"
 	"errors"
-	"time"
 
 	"github.com/darylhjd/oams/backend/internal/database/gen/postgres/public/model"
 	. "github.com/darylhjd/oams/backend/internal/database/gen/postgres/public/table"
@@ -215,47 +214,5 @@ func (d *DB) RegisterUser(ctx context.Context, arg RegisterUserParams) (model.Us
 		return d.GetUser(ctx, arg.ID)
 	}
 
-	return res, err
-}
-
-type UpcomingClassGroupSession struct {
-	Code      string          `alias:"class.code" json:"code"`
-	Year      int32           `alias:"class.year" json:"year"`
-	Semester  string          `alias:"class.semester" json:"semester"`
-	Name      string          `alias:"class_group.name" json:"name"`
-	ClassType model.ClassType `alias:"class_group.class_type" json:"class_type"`
-	StartTime time.Time       `alias:"class_group_session.start_time" json:"start_time"`
-	EndTime   time.Time       `alias:"class_group_session.end_time" json:"end_time"`
-	Venue     string          `alias:"class_group_session.venue" json:"venue"`
-}
-
-// GetUserUpcomingClassGroupSessions gets information on a user's upcoming classes. This query returns all session
-// enrollments for that user that are currently happening or will happen in the future. The sessions are returned in
-// ascending order of start time and then end time.
-func (d *DB) GetUserUpcomingClassGroupSessions(ctx context.Context, id string) ([]UpcomingClassGroupSession, error) {
-	var res []UpcomingClassGroupSession
-
-	stmt := SELECT(
-		Classes.Code, Classes.Year, Classes.Semester,
-		ClassGroups.Name, ClassGroups.ClassType,
-		ClassGroupSessions.StartTime, ClassGroupSessions.EndTime, ClassGroupSessions.Venue,
-	).FROM(
-		ClassGroupSessions.
-			INNER_JOIN(ClassGroups, ClassGroups.ID.EQ(ClassGroupSessions.ClassGroupID)).
-			INNER_JOIN(Classes, Classes.ID.EQ(ClassGroups.ClassID)),
-	).WHERE(
-		ClassGroupSessions.ID.IN(
-			SELECT(SessionEnrollments.SessionID).
-				FROM(SessionEnrollments).
-				WHERE(SessionEnrollments.UserID.EQ(String(id))),
-		).AND(
-			ClassGroupSessions.EndTime.GT(TimestampzT(time.Now())),
-		),
-	).ORDER_BY(
-		ClassGroupSessions.StartTime.ASC(),
-		ClassGroupSessions.EndTime.ASC(),
-	)
-
-	err := stmt.QueryContext(ctx, d.qe, &res)
 	return res, err
 }

--- a/frontend/src/api/user.ts
+++ b/frontend/src/api/user.ts
@@ -1,5 +1,3 @@
-import { ClassType } from "./class_group";
-
 export type UsersGetResponse = {
   users: User[];
 };
@@ -10,17 +8,7 @@ export type UserGetResponse = {
 
 export type UserMeResponse = {
   session_user: User;
-  upcoming_class_group_sessions: UpcomingClassGroupSession[];
-};
-
-export type UpcomingClassGroupSession = {
-  code: string;
-  year: number;
-  semester: string;
-  name: string;
-  class_type: ClassType;
-  start_time: Date;
-  end_time: Date;
+  managed_class_groups: number[];
 };
 
 export type User = {

--- a/frontend/src/components/header.tsx
+++ b/frontend/src/components/header.tsx
@@ -20,12 +20,12 @@ import {
   Divider,
   Flex,
   Space,
-  DrawerContent,
 } from "@mantine/core";
 import { usePathname, useRouter } from "next/navigation";
 import { useSessionUserStore } from "@/stores/session";
 import { useDisclosure } from "@mantine/hooks";
 import {
+  IconCheck,
   IconChevronDown,
   IconFileDescription,
   IconLayoutDashboard,
@@ -120,21 +120,22 @@ function GuestItems() {
 function LoggedItems() {
   const session = useSessionUserStore();
 
+  const isSystemAdmin = session.data?.session_user.role == UserRole.SystemAdmin;
+  const isClassGroupManager = session.data?.managed_class_groups.length != 0;
+
   return (
     <>
       <Group visibleFrom="md">
-        {session.data?.session_user.role == UserRole.SystemAdmin ? (
-          <SystemAdminMenu />
-        ) : null}
+        {isSystemAdmin ? <SystemAdminMenu /> : null}
+        {isClassGroupManager ? <ClassGroupManagerMenu /> : null}
         <AboutButton />
         <ProfileButton />
         <LogoutButton />
       </Group>
 
       <Stack hiddenFrom="md" gap={0}>
-        {session.data?.session_user.role == UserRole.SystemAdmin ? (
-          <SystemAdminMenu />
-        ) : null}
+        {isSystemAdmin ? <SystemAdminMenu /> : null}
+        {isClassGroupManager ? <ClassGroupManagerMenu /> : null}
         <AboutButton />
         <Divider my="sm" />
 
@@ -215,6 +216,56 @@ function LogoutButton() {
   );
 }
 
+function ClassGroupManagerMenu() {
+  const router = useRouter();
+
+  return (
+    <>
+      <Box visibleFrom="md">
+        <Menu
+          width={200}
+          classNames={{
+            dropdown: styles.menuDropdown,
+          }}
+        >
+          <MenuTarget>
+            <Button
+              color="red"
+              variant="subtle"
+              rightSection={<IconChevronDown />}
+            >
+              Class Group Manager Menu
+            </Button>
+          </MenuTarget>
+          <MenuDropdown>
+            <MenuItem
+              leftSection={<IconCheck size={16} />}
+              onClick={() => router.push(Routes.attendanceTaking)}
+            >
+              Attendance Taking
+            </MenuItem>
+          </MenuDropdown>
+        </Menu>
+      </Box>
+
+      <NavLink
+        color="red"
+        hiddenFrom="md"
+        label="Class Group Manager Menu"
+        active
+        variant="subtle"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <NavLink
+          label="Attendance Taking"
+          leftSection={<IconCheck size={16} />}
+          onClick={() => router.push(Routes.attendanceTaking)}
+        />
+      </NavLink>
+    </>
+  );
+}
+
 function SystemAdminMenu() {
   const router = useRouter();
 
@@ -224,7 +275,7 @@ function SystemAdminMenu() {
         <Menu
           width={200}
           classNames={{
-            dropdown: styles.systemAdminMenuDropdown,
+            dropdown: styles.menuDropdown,
           }}
         >
           <MenuTarget>

--- a/frontend/src/routing/routes.ts
+++ b/frontend/src/routing/routes.ts
@@ -9,4 +9,5 @@ export const Routes = {
   adminPanelClassGroupSession: "/admin-panel/class-group-sessions/",
   adminPanelSessionEnrollment: "/admin-panel/session-enrollments/",
   batchProcessing: "/batch-processing",
+  attendanceTaking: "/attendance-taking",
 };

--- a/frontend/src/styles/Header.module.css
+++ b/frontend/src/styles/Header.module.css
@@ -27,7 +27,7 @@
   }
 }
 
-.systemAdminMenuDropdown {
+.menuDropdown {
   z-index: 402 !important;
 }
 


### PR DESCRIPTION
## Issue

Currently, there is no way for a manager to take attendance. To prepare for this, we set up a way for the frontend to provide this functionality through adding a class group manager menu.

## Describe this PR

1. Remove unused upcoming class group session information.
2. Add field to show managed classes.
3. Add frontend menu.
4. Make z-index for menu dropdown more generic.

## Test Plan
```go test ./...```

## Rollback Plan
Revert the PR.