### PR TITLE
fix(frontend): show manager menu for system admins

### DIFF
--- a/frontend/src/components/header.tsx
+++ b/frontend/src/components/header.tsx
@@ -121,7 +121,8 @@ function LoggedItems() {
   const session = useSessionUserStore();
 
   const isSystemAdmin = session.data?.session_user.role == UserRole.SystemAdmin;
-  const isClassGroupManager = session.data?.has_managed_class_groups;
+  const isClassGroupManager =
+    session.data?.has_managed_class_groups || isSystemAdmin;
 
   return (
     <>

--- a/frontend/src/components/session_checker.tsx
+++ b/frontend/src/components/session_checker.tsx
@@ -37,9 +37,12 @@ export function IsClassGroupManager({
 }) {
   const session = useSessionUserStore();
 
-  if (!session.data?.has_managed_class_groups) {
-    return <NotFoundPage />;
+  if (
+    session.data?.has_managed_class_groups ||
+    session.data?.session_user.role == UserRole.SystemAdmin
+  ) {
+    return <>{children}</>;
   }
 
-  return <>{children}</>;
+  return <NotFoundPage />;
 }


### PR DESCRIPTION
## Issue

Currently, the manager menu is not shown even if the user is a system admin. We change the logic to show it if there are managed class groups or if the user is a system admin.

## Describe this PR

1. Change logic for showing menu as well as the attendance taking page.

## Test Plan

Test on local admin panel.

## Rollback Plan
Revert the PR.