### PR TITLE
feat: implement upcoming session card

### DIFF
--- a/backend/internal/servers/apiserver/v1/attendance_taking.go
+++ b/backend/internal/servers/apiserver/v1/attendance_taking.go
@@ -30,6 +30,9 @@ type attendanceTakingGetUpcomingClassGroupSessionResponseFields struct {
 	StartTime    time.Time           `json:"start_time"`
 	EndTime      time.Time           `json:"end_time"`
 	Venue        string              `json:"venue"`
+	Code         string              `json:"code"`
+	Year         int32               `json:"year"`
+	Semester     string              `json:"semester"`
 	ClassType    model.ClassType     `json:"class_type"`
 	ManagingRole *model.ManagingRole `json:"managing_role"`
 }
@@ -53,6 +56,9 @@ func (v *APIServerV1) attendanceTakingGet(r *http.Request) apiResponse {
 			m.StartTime,
 			m.EndTime,
 			m.Venue,
+			m.Code,
+			m.Year,
+			m.Semester,
 			m.ClassType,
 			m.ManagingRole,
 		})

--- a/frontend/src/api/attendance_taking.ts
+++ b/frontend/src/api/attendance_taking.ts
@@ -10,6 +10,9 @@ export type UpcomingClassGroupSession = {
   start_time: Date;
   end_time: Date;
   venue: string;
+  code: string;
+  year: number;
+  semester: string;
   class_type: ClassType;
   managing_role: ManagingRole | null;
 };

--- a/frontend/src/app/attendance-taking/page.tsx
+++ b/frontend/src/app/attendance-taking/page.tsx
@@ -72,7 +72,7 @@ function PageTitle() {
       </>
 
       <Tooltip
-        label="Only sessions starting in 15 minutes will be shown!"
+        label="Only sessions beginning in less than 15 minutes are shown."
         events={{
           hover: true,
           focus: false,
@@ -102,21 +102,40 @@ function UpcomingSessionsGrid({
 
   return (
     <>
-      <Text ta="center">You have {sessions.length} upcoming sessions.</Text>
-      <>
-        <SimpleGrid visibleFrom="sm" cols={3}>
-          {sessionCards}
-        </SimpleGrid>
-        <SimpleGrid hiddenFrom="sm" cols={1}>
-          {sessionCards}
-        </SimpleGrid>
-      </>
+      <Text ta="center">
+        You have{" "}
+        <Text span c="green">
+          {sessions.length}
+        </Text>{" "}
+        upcoming sessions.
+      </Text>
+      <Space h="md" />
+      <Group justify="center">{sessionCards}</Group>
     </>
   );
 }
 
 function SessionCard({ session }: { session: UpcomingClassGroupSession }) {
   const router = useRouter();
+
+  const startDatetime = new Date(session.start_time);
+  const endDatetime = new Date(session.end_time);
+
+  const date = startDatetime.toLocaleString(undefined, {
+    day: "numeric",
+    month: "numeric",
+    year: "numeric",
+  });
+  const startTime = startDatetime.toLocaleString(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+  const endTime = endDatetime.toLocaleString(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+
+  const isOngoing = new Date() >= startDatetime;
 
   return (
     <Paper
@@ -126,9 +145,29 @@ function SessionCard({ session }: { session: UpcomingClassGroupSession }) {
       component="button"
       onClick={() => router.push(Routes.attendanceTakingSession + session.id)}
     >
-      <Text ta="center">{session.venue}</Text>
-      <Space h="md" />
-      <Text ta="center">
+      <Text ta="left">
+        {session.code}{" "}
+        <Text span size="sm" c="dimmed">
+          {session.year}/{session.semester}
+        </Text>
+      </Text>
+      <Text ta="left" size="xs">
+        Class Type: {session.class_type}
+      </Text>
+      <Text ta="left" size="xs">
+        Venue: {session.venue}
+      </Text>
+      <Space h="xs" />
+      <Text ta="left" size="xs">
+        {date}
+        <br />
+        {startTime} - {endTime}
+      </Text>
+      <Text ta="left" size="xs" c={isOngoing ? "green" : "orange"}>
+        {isOngoing ? "ONGOING" : "STARTING"}
+      </Text>
+      <Space h="xs" />
+      <Text ta="left" size="xs" c="dimmed">
         {session.managing_role ? session.managing_role : UserRole.SystemAdmin}
       </Text>
     </Paper>

--- a/frontend/src/styles/AttendanceTakingPage.module.css
+++ b/frontend/src/styles/AttendanceTakingPage.module.css
@@ -8,4 +8,12 @@
 
 .sessionCard {
   cursor: pointer;
+  width: rem(300px);
+
+  @mixin hover {
+    background-color: light-dark(
+      var(--mantine-color-gray-0),
+      var(--mantine-color-dark-5)
+    );
+  }
 }


### PR DESCRIPTION
## Issue

Currently, the upcoming session card does not show enough information.

We add more information here.

## Describe this PR

1. Add more information provided by the API.
2. Sort the sessions by start time.
3. Add hover css for the card.

## Test Plan
Test on local admin panel.

## Rollback Plan
Revert the PR.