### PR TITLE
fix: hide fact that no signature exists for default signature

### DIFF
--- a/backend/internal/database/attendance_takings.go
+++ b/backend/internal/database/attendance_takings.go
@@ -104,9 +104,9 @@ func (d *DB) UpdateSessionEnrollmentAttendance(ctx context.Context, arg UpdateSe
 	}
 
 	match, err := argon2id.ComparePasswordAndHash(arg.UserSignature, signature.Signature)
-	if !match {
+	if err != nil {
 		return res, qrm.ErrNoRows
-	} else if err != nil {
+	} else if !match {
 		return res, err
 	}
 


### PR DESCRIPTION
## Issue

Note that the comparision takes a long time.

## Describe this PR

1. Create hash for default passwords.

## Test Plan

## Rollback Plan
