### PR TITLE
fix(frontend): wrong tooltip minutes shown for attendance taking

### DIFF
--- a/frontend/src/app/attendance-taking/page.tsx
+++ b/frontend/src/app/attendance-taking/page.tsx
@@ -36,7 +36,7 @@ function PageTitle() {
         Upcoming Class Group Sessions
       </Title>
       <Tooltip
-        label="Only sessions beginning in less than 15 minutes are shown."
+        label="Only sessions beginning in less than 30 minutes are shown."
         events={{
           hover: true,
           focus: false,


### PR DESCRIPTION
## Issue

## Describe this PR

## Test Plan

## Rollback Plan
